### PR TITLE
Implement authorization scopes.

### DIFF
--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -22,10 +22,28 @@ interface AuthorizationServiceInterface
     /**
      * Check whether the provided user can perform an action on a resource.
      *
+     * This method is intended to allow your application to build
+     * conditional logic around authorization checks.
+     *
      * @param \Authorization\IdentityInterface $user The user to check permissions for.
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
      * @return bool
      */
     public function can(IdentityInterface $user, $action, $resource);
+
+    /**
+     * Apply authorization scope conditions/restrictions.
+     *
+     * This method is intended for applying authorization to objects that
+     * are then used to access authorized collections of objects. The typical
+     * use case for scopes are restricting a query to only return records
+     * visible to the current user.
+     *
+     * @param \Authorization\IdentityInterface $user The user to check permissions for.
+     * @param string $action The action/operation being performed.
+     * @param mixed $resource The resource being operated on.
+     * @return mixed The modified resource.
+     */
+    public function applyScope(IdentityInterface $user, $action, $resource);
 }

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -62,11 +62,19 @@ class IdentityDecorator implements IdentityInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function can($action, $resource)
     {
         return $this->authorization->can($this, $action, $resource);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function applyScope($action, $resource)
+    {
+        return $this->authorization->applyScope($this, $action, $resource);
     }
 
     /**

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -35,6 +35,15 @@ interface IdentityInterface extends ArrayAccess
     public function can($action, $resource);
 
     /**
+     * Apply authorization scope conditions/restrictions.
+     *
+     * @param string $action The action/operation being performed.
+     * @param mixed $resource The resource being operated on.
+     * @return mixed The modified resource.
+     */
+    public function applyScope($action, $resource);
+
+    /**
      * Get the decorated identity
      *
      * If the decorated identity implements `getOriginalData()`

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -42,6 +42,40 @@ class AuthorizationServiceTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testApplyScope()
+    {
+        $resolver = new MapResolver([
+            Article::class => ArticlePolicy::class
+        ]);
+        $service = new AuthorizationService($resolver);
+        $user = new IdentityDecorator($service, [
+            'id' => 9,
+            'role' => 'admin'
+        ]);
+
+        $article = new Article();
+        $result = $service->applyScope($user, 'index', $article);
+        $this->assertSame($article, $result);
+        $this->assertSame($article->user_id, $user->getOriginalData()['id']);
+    }
+
+    public function testApplyScopeMethodMissing()
+    {
+        $this->expectException(MissingMethodException::class);
+
+        $resolver = new MapResolver([
+            Article::class => ArticlePolicy::class
+        ]);
+        $service = new AuthorizationService($resolver);
+        $user = new IdentityDecorator($service, [
+            'id' => 9,
+            'role' => 'admin'
+        ]);
+
+        $article = new Article();
+        $result = $service->applyScope($user, 'nope', $article);
+    }
+
     public function testBeforeFalse()
     {
         $entity = new Article();

--- a/tests/TestCase/IdentityDecoratorTest.php
+++ b/tests/TestCase/IdentityDecoratorTest.php
@@ -60,6 +60,19 @@ class IdentityDecoratorTest extends TestCase
         $this->assertTrue($identity->can('update', $resource));
     }
 
+    public function testApplyScopeDelegation()
+    {
+        $resource = new stdClass();
+        $auth = $this->createMock(AuthorizationServiceInterface::class);
+        $identity = new IdentityDecorator($auth, ['id' => 1]);
+
+        $auth->expects($this->once())
+            ->method('applyScope')
+            ->with($identity, 'update', $resource)
+            ->will($this->returnValue(true));
+        $this->assertTrue($identity->applyScope('update', $resource));
+    }
+
     public function testCall()
     {
         $data = new Article(['id' => 1]);

--- a/tests/test_app/TestApp/Policy/ArticlePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlePolicy.php
@@ -9,7 +9,7 @@ class ArticlePolicy
     /**
      * Create articles if you're an admin or author
      *
-     * @param array $user
+     * @param \Authorization\IdentityInterface $user
      * @return bool
      */
     public function canAdd($user)
@@ -29,7 +29,7 @@ class ArticlePolicy
     /**
      * Delete only own articles or any if you're an admin
      *
-     * @param array $user
+     * @param \Authorization\IdentityInterface $user
      * @param Article $article
      * @return bool
      */
@@ -40,5 +40,19 @@ class ArticlePolicy
         }
 
         return $user['id'] === $article->get('user_id');
+    }
+
+    /**
+     * Scope method for index
+     *
+     * @param \Authorization\IdentityInterface $user
+     * @param Article $article
+     * @return bool
+     */
+    public function scopeIndex($user, Article $article)
+    {
+        $article->user_id = $user->getOriginalData()['id'];
+
+        return $article;
     }
 }


### PR DESCRIPTION
Allow authorization policies to mutate objects in place. This enables query objects to have conditions applied or pre-compute authorization checks on a collection of objects.