### PR TITLE
Enable automatic fixing of phpcs errors.

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,12 @@
 linters:
   phpcs:
     standard: CakePHP
+    fixer: true
+
 files:
   ignore:
     - 'vendor/*'
+
+fixers:
+  enable: true
+  workflow: 'commit'


### PR DESCRIPTION
In the future stickler will push a commit to pull requests that contain phpcs errors.