### PR TITLE
Make OrmResolver able to resolve Query objects.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -53,4 +53,12 @@
 		</whitelist>
 	</filter>
 
+	<php>
+		<!-- Postgres
+		<env name="db_dsn" value="postgres://root@localhost/cake_test_db"/>
+		-->
+		<!-- Mysql
+		<env name="db_dsn" value="mysql://root@localhost/cake_test_db"/>
+		-->
+	</php>
 </phpunit>

--- a/src/Policy/OrmResolver.php
+++ b/src/Policy/OrmResolver.php
@@ -17,6 +17,7 @@ namespace Authorization\Policy;
 use Authorization\Policy\Exception\MissingPolicyException;
 use Cake\Core\App;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
 use InvalidArgumentException;
 
@@ -58,6 +59,9 @@ class OrmResolver implements ResolverInterface
         }
         if ($resource instanceof RepositoryInterface) {
             return $this->getRepositoryPolicy($resource);
+        }
+        if ($resource instanceof QueryInterface) {
+            return $this->getRepositoryPolicy($resource->repository());
         }
         $name = is_object($resource) ? get_class($resource) : gettype($resource);
         throw new MissingPolicyException([$name]);

--- a/tests/TestCase/Policy/OrmResolverTest.php
+++ b/tests/TestCase/Policy/OrmResolverTest.php
@@ -17,6 +17,7 @@ namespace Authorization\Test\TestCase\Policy;
 use Authorization\Policy\Exception\MissingPolicyException;
 use Authorization\Policy\OrmResolver;
 use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Table\ArticlesTable;
@@ -29,6 +30,8 @@ use TestPlugin\Policy\TagPolicy;
 
 class OrmResolverTest extends TestCase
 {
+    public $fixtures = ['core.articles'];
+
     public function testGetPolicyUnknownObject()
     {
         $this->expectException(MissingPolicyException::class);
@@ -76,9 +79,17 @@ class OrmResolverTest extends TestCase
 
     public function testGetPolicyDefinedTable()
     {
-        $articles = new ArticlesTable();
+        $articles = TableRegistry::get('Articles');
         $resolver = new OrmResolver('TestApp');
         $policy = $resolver->getPolicy($articles);
+        $this->assertInstanceOf(ArticlesTablePolicy::class, $policy);
+    }
+
+    public function testGetPolicyQueryForDefinedTable()
+    {
+        $articles = TableRegistry::get('Articles');
+        $resolver = new OrmResolver('TestApp');
+        $policy = $resolver->getPolicy($articles->find());
         $this->assertInstanceOf(ArticlesTablePolicy::class, $policy);
     }
 


### PR DESCRIPTION
By using the `repository()` method we can get the primary resource the query will be for. This makes it easier to apply query scopes to ORM queries.