### PR TITLE
Add ability to ensure authorization was checked.

### DIFF
--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -29,6 +29,13 @@ class AuthorizationService implements AuthorizationServiceInterface
     protected $resolver;
 
     /**
+     * Track whether or not authorization was checked.
+     *
+     * @var bool
+     */
+    protected $authorizationChecked = false;
+
+    /**
      *
      * @param \Authorization\Policy\ResolverInterface $resolver Authorization policy resolver.
      */
@@ -42,6 +49,7 @@ class AuthorizationService implements AuthorizationServiceInterface
      */
     public function can(IdentityInterface $user, $action, $resource)
     {
+        $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);
 
         if ($policy instanceof BeforePolicyInterface) {
@@ -66,6 +74,7 @@ class AuthorizationService implements AuthorizationServiceInterface
      */
     public function applyScope(IdentityInterface $user, $action, $resource)
     {
+        $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);
         $handler = $this->getScopeHandler($policy, $action);
 
@@ -108,5 +117,13 @@ class AuthorizationService implements AuthorizationServiceInterface
         }
 
         return [$policy, $method];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function authorizationChecked()
+    {
+        return $this->authorizationChecked;
     }
 }

--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -46,4 +46,12 @@ interface AuthorizationServiceInterface
      * @return mixed The modified resource.
      */
     public function applyScope(IdentityInterface $user, $action, $resource);
+
+    /**
+     * Return a boolean based on whether or not this object
+     * has had an authorization operation performed.
+     *
+     * @return bool
+     */
+    public function authorizationChecked();
 }

--- a/src/Exception/AuthorizationRequiredException.php
+++ b/src/Exception/AuthorizationRequiredException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authorization\Exception;
+
+use Authorization\Exception\Exception as BaseException;
+
+/**
+ * Exception raised when authorization is required.
+ */
+class AuthorizationRequiredException extends BaseException
+{
+    protected $_messageTemplate = 'The request to `%s` did not apply any authorization checks.';
+}

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -42,6 +42,39 @@ class AuthorizationServiceTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testAuthorizationCheckedWithCan()
+    {
+        $resolver = new MapResolver([
+            Article::class => ArticlePolicy::class
+        ]);
+        $service = new AuthorizationService($resolver);
+        $this->assertFalse($service->authorizationChecked());
+
+        $user = new IdentityDecorator($service, [
+            'role' => 'admin'
+        ]);
+
+        $service->can($user, 'add', new Article);
+        $this->assertTrue($service->authorizationChecked());
+    }
+
+    public function testAuthorizationCheckedWithApplyScope()
+    {
+        $resolver = new MapResolver([
+            Article::class => ArticlePolicy::class
+        ]);
+        $service = new AuthorizationService($resolver);
+        $this->assertFalse($service->authorizationChecked());
+
+        $user = new IdentityDecorator($service, [
+            'id' => 9,
+            'role' => 'admin'
+        ]);
+
+        $service->applyScope($user, 'index', new Article);
+        $this->assertTrue($service->authorizationChecked());
+    }
+
     public function testApplyScope()
     {
         $resolver = new MapResolver([


### PR DESCRIPTION
I've found this to be a helpful feature in other libraries during development/testing. It helps you ensure that your controller actions all check authorization. Failing to check authorization will trigger an exception which will fail the test.

If we add a way to 'skip' authorization in the future it should also modify this flag as skipping authorization is a type of 'check'.