### PR TITLE
Move `IdentityInterface` instance check to `buildIdentity()`.

### DIFF
--- a/src/Middleware/AuthorizationMiddleware.php
+++ b/src/Middleware/AuthorizationMiddleware.php
@@ -105,9 +105,7 @@ class AuthorizationMiddleware
             return $next($request, $response);
         }
 
-        if (!$identity instanceof IdentityInterface) {
-            $identity = $this->buildIdentity($service, $identity);
-        }
+        $identity = $this->buildIdentity($service, $identity);
 
         $request = $request->withAttribute($attribute, $identity);
         $response = $next($request, $response);
@@ -166,7 +164,9 @@ class AuthorizationMiddleware
         if (is_callable($class)) {
             $identity = $class($service, $identity);
         } else {
-            $identity = new $class($service, $identity);
+            if (!$identity instanceof IdentityInterface) {
+                $identity = new $class($service, $identity);
+            }
         }
 
         if (!$identity instanceof IdentityInterface) {

--- a/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
@@ -258,7 +258,9 @@ class AuthorizationMiddlewareTest extends TestCase
 
     public function testCustomIdentityDecorator()
     {
-        $identity = $this->createMock(Identity::class);
+        $identity = new Identity([
+            'id' => 1
+        ]);
 
         $service = $this->createMock(AuthorizationServiceInterface::class);
         $request = (new ServerRequest)->withAttribute('identity', $identity);
@@ -275,17 +277,13 @@ class AuthorizationMiddlewareTest extends TestCase
             },
             'requireAuthorizationCheck' => false,
         ]);
-
-        $identity->expects($this->once())
-            ->method('setService')
-            ->with($service);
-
         $result = $middleware($request, $response, $next);
 
         $this->assertInstanceOf(RequestInterface::class, $result);
         $this->assertSame($service, $result->getAttribute('authorization'));
         $this->assertInstanceOf(IdentityInterface::class, $result->getAttribute('identity'));
         $this->assertSame($identity, $result->getAttribute('identity'));
+        $this->assertSame($service, $result->getAttribute('identity')->getService());
     }
 
     public function testInvalidIdentity()

--- a/tests/test_app/TestApp/Identity.php
+++ b/tests/test_app/TestApp/Identity.php
@@ -1,0 +1,12 @@
+<?php
+namespace TestApp;
+
+use Authorization\AuthorizationServiceInterface;
+use Authorization\IdentityDecorator;
+
+class Identity extends IdentityDecorator
+{
+    public function setService(AuthorizationServiceInterface $service)
+    {
+    }
+}

--- a/tests/test_app/TestApp/Identity.php
+++ b/tests/test_app/TestApp/Identity.php
@@ -6,7 +6,18 @@ use Authorization\IdentityDecorator;
 
 class Identity extends IdentityDecorator
 {
+    public function __construct($identity)
+    {
+        $this->identity = $identity;
+    }
+
     public function setService(AuthorizationServiceInterface $service)
     {
+        $this->authorization = $service;
+    }
+
+    public function getService()
+    {
+        return $this->authorization;
     }
 }


### PR DESCRIPTION
Current implementation does not allow to call custom callable decorators
on existing `IdentityInterface` instances. This makes it impossible to
easily inject authorization service into custom identity instances.