### PR TITLE
Add authorization bypassing

### DIFF
--- a/docs/Middleware-and-Component.md
+++ b/docs/Middleware-and-Component.md
@@ -150,14 +150,52 @@ If you want to map actions to different authorization methods use the `actionMap
 ```php
 $this->loadComponent('Authorization.Authorization', [
     'actionMap' => [
-        'update' => 'modify',
+        'index' => 'list',
         'delete' => 'remove',
+        'add' => 'insert',
     ]
 ];
 ```
 
-Authorization can also be skipped manually, e.g. from action body:
+Example:
 
 ```php
-$this->Authorization->skipAuthorization();
+//ArticlesController.php
+
+public function index()
+{
+    $query = $this->Articles->find();
+
+    //this will apply `list` scope while being called in `index` controller action.
+    $this->Authorizaton->applyScope($query); 
+    ...
+}
+
+public function delete($id)
+{
+    $article = $this->Articles->get($id);
+
+    //this will authorize against `remove` entity action while being called in `delete` controller action.
+    $this->Authorizaton->authorize($article); 
+    ...
+}
+
+public function add()
+{
+    //this will authorize against `insert` model action while being called in `add` controller action.
+    $this->Authorizaton->authorizeModel(); 
+    ...
+}
+```
+
+Authorization can also be skipped manually:
+
+```php
+//ArticlesController.php
+
+public function view($id)
+{
+    $this->Authorization->skipAuthorization();
+    ...
+}
 ```

--- a/docs/Middleware-and-Component.md
+++ b/docs/Middleware-and-Component.md
@@ -86,30 +86,17 @@ public function initialize()
 
 ### Automatic authorization checks
 
-By default `AuthorizationComponent` will attempt to automatically apply
+`AuthorizationComponent` can be configured to automatically apply
 authorization based on the controller's default model class and current action
-name. You can disable this behavior entirely or configure it for individual actions 
-using the `authorizeModel` option.
+name. You can configure this for individual actions using the `authorizeModel` option.
 
-
-In the following example all actions will be authorized except the `index` action:
+In the following example `index` and `add` actions will be authorized:
 
 ```php
 $this->loadComponent('Authorization.Authorization', [
     'authorizeModel' => [
-        'index' => false,
-    ]
-];
-```
-
-You can control default check for all actions using a *wildcard character* `*`.
-In the following example only `add` action would be authorized automatically:
-
-```php
-$this->loadComponent('Authorization.Authorization', [
-    'authorizeModel' => [
-        '*' => false,
-        'add' => true,
+        'index',
+        'add',
     ]
 ];
 ```
@@ -123,17 +110,7 @@ Authorization can be skipped for individual actions:
 ```php
 $this->loadComponent('Authorization.Authorization', [
     'skipAuthorization' => [
-        'login' => true,
-    ]
-];
-```
-
-Authorization bypass can be configured for all actions as well:
-
-```php
-$this->loadComponent('Authorization.Authorization', [
-    'skipAuthorization' => [
-        '*' => true,
+        'login',
     ]
 ];
 ```

--- a/docs/Middleware-and-Component.md
+++ b/docs/Middleware-and-Component.md
@@ -88,22 +88,28 @@ public function initialize()
 
 By default `AuthorizationComponent` will attempt to automatically apply
 authorization based on the controller's default model class and current action
-name. You can disable this behavior entirely using the `authorizeModel` option:
+name. You can disable this behavior entirely or configure it for individual actions 
+using the `authorizeModel` option.
+
+
+In the following example all actions will be authorized except the `index` action:
 
 ```php
 $this->loadComponent('Authorization.Authorization', [
-    'authorizeModel' => false
+    'authorizeModel' => [
+        'index' => false,
+    ]
 ];
 ```
 
-If you want to exclude some actions from automatic authorization, or map actions to
-different authorization methods use the `actionMap` option:
+You can control default check for all actions using a *wildcard character* `*`.
+In the following example only `add` action would be authorized automatically:
 
 ```php
 $this->loadComponent('Authorization.Authorization', [
-    'actionMap' => [
-        'update' => 'modify',
-        'delete' => false,
+    'authorizeModel' => [
+        '*' => false,
+        'add' => true,
     ]
 ];
 ```
@@ -139,4 +145,15 @@ You can also apply policy scopes using the component:
 
 ```php
 $query = $this->Authorization->applyScope($this->Articles->find());
+```
+
+If you want to map actions to different authorization methods use the `actionMap` option:
+
+```php
+$this->loadComponent('Authorization.Authorization', [
+    'actionMap' => [
+        'update' => 'modify',
+        'delete' => 'remove',
+    ]
+];
 ```

--- a/docs/Middleware-and-Component.md
+++ b/docs/Middleware-and-Component.md
@@ -114,8 +114,29 @@ $this->loadComponent('Authorization.Authorization', [
 ];
 ```
 
-Any action not set to `false` in the `actionMap` will have authorization checked
-automatically.
+You can also configure actions to skip authorization. This will make actions *public*,
+accessible to all users. By default all actions require authorization and
+`AuthorizationRequiredException` will be thrown if authorization checking is enabled.
+
+Authorization can be skipped for individual actions:
+
+```php
+$this->loadComponent('Authorization.Authorization', [
+    'skipAuthorization' => [
+        'login' => true,
+    ]
+];
+```
+
+Authorization bypass can be configured for all actions as well:
+
+```php
+$this->loadComponent('Authorization.Authorization', [
+    'skipAuthorization' => [
+        '*' => true,
+    ]
+];
+```
 
 ### Component Usage
 
@@ -132,7 +153,7 @@ public function edit($id)
 }
 ```
 
-Above we see an article being authorized for the current user. By the current
+Above we see an article being authorized for the current user. By default the current
 request's `action` is used for the policy method. You can choose
 a policy method to use if necessary:
 
@@ -156,4 +177,10 @@ $this->loadComponent('Authorization.Authorization', [
         'delete' => 'remove',
     ]
 ];
+```
+
+Authorization can also be skipped manually, e.g. from action body:
+
+```php
+$this->Authorization->skipAuthorization();
 ```

--- a/docs/Middleware-and-Component.md
+++ b/docs/Middleware-and-Component.md
@@ -60,6 +60,13 @@ $middlewareStack->add(new AuthorizationMiddleware($this, [
 ]));
 ```
 
+You can bypass the authorization check for individual requests by calling method
+`skipAuthorization()` on `AuthorizationService` instance:
+
+```php
+$request->getAttribute('authorization')->skipAuthorization();
+```
+
 # AuthorizationComponent
 
 The `AuthorizationComponent` exposes a few conventions based helper methods for

--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -126,4 +126,14 @@ class AuthorizationService implements AuthorizationServiceInterface
     {
         return $this->authorizationChecked;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function skipAuthorization()
+    {
+        $this->authorizationChecked = true;
+
+        return $this;
+    }
 }

--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -54,4 +54,14 @@ interface AuthorizationServiceInterface
      * @return bool
      */
     public function authorizationChecked();
+
+    /**
+     * Allow for authorization to be skipped for this object.
+     *
+     * After calling this method the value of `authorizationChecked()` should
+     * return `true` regardless of whether authorization has been performed or not.
+     *
+     * @return $this
+     */
+    public function skipAuthorization();
 }

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -14,9 +14,9 @@
  */
 namespace Authorization\Controller\Component;
 
+use Authorization\Exception\ForbiddenException;
 use Authorization\IdentityInterface;
 use Cake\Controller\Component;
-use Cake\Network\Exception\ForbiddenException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use UnexpectedValueException;
@@ -38,7 +38,6 @@ class AuthorizationComponent extends Component
      */
     protected $_defaultConfig = [
         'identityAttribute' => 'identity',
-        'forbiddenException' => ForbiddenException::class,
         'authorizationEvent' => 'Controller.initialize',
         'authorizeModel' => true,
         'actionMap' => []
@@ -63,8 +62,7 @@ class AuthorizationComponent extends Component
         }
         $identity = $this->getIdentity($request);
         if (!$identity->can($action, $resource)) {
-            $class = $this->getConfig('forbiddenException');
-            throw new $class();
+            throw new ForbiddenException([$action, get_class($resource)]);
         }
     }
 

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -35,11 +35,6 @@ class AuthorizationComponent extends Component
 {
 
     /**
-     * Constant for all actions config key.
-     */
-    const ALL = '*';
-
-    /**
      * Default config
      *
      * @var array
@@ -48,12 +43,8 @@ class AuthorizationComponent extends Component
         'identityAttribute' => 'identity',
         'serviceAttribute' => 'authorization',
         'authorizationEvent' => 'Controller.initialize',
-        'skipAuthorization' => [
-            self::ALL => false,
-        ],
-        'authorizeModel' => [
-            self::ALL => true,
-        ],
+        'skipAuthorization' => [],
+        'authorizeModel' => [],
         'actionMap' => []
     ];
 
@@ -202,12 +193,9 @@ class AuthorizationComponent extends Component
      */
     protected function checkAction($action, $configKey)
     {
-        $value = $this->getConfig($configKey . '.' . $action);
-        if (is_bool($value)) {
-            return $value;
-        }
+        $actions = (array)$this->getConfig($configKey);
 
-        return (bool)$this->getConfig($configKey . '.' . static::ALL);
+        return in_array($action, $actions, true);
     }
 
     /**

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Authorization\Exception;
+
+class ForbiddenException extends Exception
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 403;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_messageTemplate = 'Identity is not authorized to perform `%s` on `%s`.';
+}

--- a/src/Exception/MissingIdentityException.php
+++ b/src/Exception/MissingIdentityException.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Authorization\Exception;
+
+class MissingIdentityException extends Exception
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 403;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_messageTemplate = 'Identity is not present in `%s` request attribute.';
+}

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -75,6 +75,16 @@ class AuthorizationServiceTest extends TestCase
         $this->assertTrue($service->authorizationChecked());
     }
 
+    public function testSkipAuthorization()
+    {
+        $resolver = new MapResolver([]);
+        $service = new AuthorizationService($resolver);
+        $this->assertFalse($service->authorizationChecked());
+
+        $service->skipAuthorization();
+        $this->assertTrue($service->authorizationChecked());
+    }
+
     public function testApplyScope()
     {
         $resolver = new MapResolver([

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -258,8 +258,8 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $this->expectException(MissingMethodException::class);
-        $this->expectExceptionMessage('Method `canModify` for invoking action `modify` has not been defined in `TestApp\Policy\ArticlePolicy`.');
+        $this->expectExceptionMessage('Method `canDisable` for invoking action `disable` has not been defined in `TestApp\Policy\ArticlePolicy`.');
 
-        $service->can($user, 'modify', $entity);
+        $service->can($user, 'disable', $entity);
     }
 }

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -16,16 +16,15 @@ namespace Authorization\Test\TestCase\Controller\Component;
 
 use Authorization\AuthorizationService;
 use Authorization\Controller\Component\AuthorizationComponent;
+use Authorization\Exception\ForbiddenException;
 use Authorization\IdentityDecorator;
 use Authorization\Policy\Exception\MissingPolicyException;
 use Authorization\Policy\MapResolver;
 use Authorization\Policy\OrmResolver;
-use BadMethodCallException;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Datasource\QueryInterface;
 use Cake\Http\ServerRequest;
-use Cake\Network\Exception\ForbiddenException;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use stdClass;
@@ -141,15 +140,6 @@ class AuthorizationComponentTest extends TestCase
         $this->Auth->authorize($article);
     }
 
-    public function testAuthorizeCustomException()
-    {
-        $this->expectException(BadMethodCallException::class);
-        $this->Auth->config('forbiddenException', BadMethodCallException::class);
-
-        $article = new Article(['user_id' => 99]);
-        $this->Auth->authorize($article);
-    }
-
     public function testAuthorizeModelSuccess()
     {
         $service = new AuthorizationService(new OrmResolver());
@@ -169,6 +159,8 @@ class AuthorizationComponentTest extends TestCase
             ->withAttribute('identity', $identity);
 
         $this->expectException(ForbiddenException::class);
+        $this->expectExceptionCode(403);
+        $this->expectExceptionMessage('Identity is not authorized to perform `edit` on `TestApp\Model\Table\ArticlesTable`.');
         $this->Auth->authorizeModel();
     }
 

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -174,6 +174,7 @@ class AuthorizationComponentTest extends TestCase
         $this->Controller->request = $this->Controller->request
             ->withAttribute('identity', $identity);
 
+        $this->Auth->setConfig('authorizeModel', ['edit']);
         $this->expectException(ForbiddenException::class);
         $this->expectExceptionCode(403);
         $this->expectExceptionMessage('Identity is not authorized to perform `edit` on `TestApp\Model\Table\ArticlesTable`.');
@@ -194,7 +195,6 @@ class AuthorizationComponentTest extends TestCase
         $policy->expects($this->never())
             ->method('canEdit');
 
-        $this->Auth->setConfig('authorizeModel', ['*' => false]);
         $result = $this->Auth->authorizeAction();
         $this->assertNull($result);
     }
@@ -206,26 +206,7 @@ class AuthorizationComponentTest extends TestCase
         $this->Controller->request = $this->Controller->request
             ->withAttribute('identity', $identity);
 
-        $this->Auth->setConfig('authorizeModel', ['edit' => true]);
-        $result = $this->Auth->authorizeAction();
-        $this->assertNull($result);
-    }
-
-    public function testAuthorizeModelActionDisabled()
-    {
-        $policy = $this->createMock(ArticlesTablePolicy::class);
-        $service = new AuthorizationService(new MapResolver([
-            ArticlesTable::class => $policy
-        ]));
-
-        $identity = new IdentityDecorator($service, ['can_edit' => true]);
-        $this->Controller->request = $this->Controller->request
-            ->withAttribute('identity', $identity);
-
-        $policy->expects($this->never())
-            ->method('canEdit');
-
-        $this->Auth->setConfig('authorizeModel', ['edit' => false]);
+        $this->Auth->setConfig('authorizeModel', ['edit']);
         $result = $this->Auth->authorizeAction();
         $this->assertNull($result);
     }
@@ -248,6 +229,7 @@ class AuthorizationComponentTest extends TestCase
             ->method('canModify')
             ->willReturn(true);
 
+        $this->Auth->setConfig('authorizeModel', ['edit']);
         $this->Auth->setConfig('actionMap', ['edit' => 'modify']);
         $result = $this->Auth->authorizeAction();
         $this->assertNull($result);
@@ -260,6 +242,7 @@ class AuthorizationComponentTest extends TestCase
         $this->Controller->request = $this->Controller->request
             ->withAttribute('identity', $identity);
 
+        $this->Auth->setConfig('authorizeModel', ['edit']);
         $this->Auth->setConfig('actionMap', ['edit' => new stdClass]);
 
         $this->expectException(UnexpectedValueException::class);
@@ -307,44 +290,16 @@ class AuthorizationComponentTest extends TestCase
     {
         $service = $this->Controller->request->getAttribute('authorization');
 
-        $this->Auth->setConfig('authorizeModel', ['*' => false]);
         $this->Auth->authorizeAction();
         $this->assertFalse($service->authorizationChecked());
-    }
-
-    public function testAuthorizeAllSkipped()
-    {
-        $service = $this->Controller->request->getAttribute('authorization');
-
-        $this->Auth->setConfig('skipAuthorization', ['*' => true]);
-        $this->Auth->setConfig('authorizeModel', ['*' => false]);
-        $this->Auth->authorizeAction();
-        $this->assertTrue($service->authorizationChecked());
     }
 
     public function testAuthorizeActionSkipped()
     {
         $service = $this->Controller->request->getAttribute('authorization');
 
-        $this->Auth->setConfig('skipAuthorization', [
-            '*' => false,
-            'edit' => true,
-        ]);
-        $this->Auth->setConfig('authorizeModel', ['*' => false]);
+        $this->Auth->setConfig('skipAuthorization', ['edit']);
         $this->Auth->authorizeAction();
         $this->assertTrue($service->authorizationChecked());
-    }
-
-    public function testAuthorizeActionNotSkipped()
-    {
-        $service = $this->Controller->request->getAttribute('authorization');
-
-        $this->Auth->setConfig('skipAuthorization', [
-            '*' => true,
-            'edit' => false,
-        ]);
-        $this->Auth->setConfig('authorizeModel', ['*' => false]);
-        $this->Auth->authorizeAction();
-        $this->assertFalse($service->authorizationChecked());
     }
 }

--- a/tests/test_app/TestApp/Policy/ArticlePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlePolicy.php
@@ -26,6 +26,15 @@ class ArticlePolicy
         return $article->get('user_id') === $user['id'];
     }
 
+    public function canModify($user, Article $article)
+    {
+        if (in_array($user['role'], ['admin', 'author'])) {
+            return true;
+        }
+
+        return $article->get('user_id') === $user['id'];
+    }
+
     /**
      * Delete only own articles or any if you're an admin
      *


### PR DESCRIPTION
This is an implementation for #25.

By default all requests require authorization check when `requireAuthorizationCheck` is set to true.
This PR adds the ability to skip authorization by calling `skipAuthorization` on service or component without executing policy check.

`AuthorizationComponent` allows for automatic authorization skipping as well.
This could be achieved by marking actions in `skipAuthorization` config array, thus making actions publicly accessible or not.

For example:
```php
$this->loadComponent('Authorization.Authorization', [
    'skipAuthorization' => [
        'login'
    ]
];
```

I refactored model authorization config to use the same approach.

Mapping action has changed it responsibility a bit. Now all authorization checks made on component without providing action name explicitly will use mapped action names. This also means that setting action names to true/false will no longer work as enabling/disabling actions has been moved to `authorizeModel` config. This makes using the map and automatic authorization simplier in my mind.

I updated the docs as well, the changes are exaplained there.


After this gets accepted and merged, I'll implement handlers for unathorized requests so for instance all `MissingIdentityException`s could be redirected to the login page.