### PR TITLE
Fix unauthorized handler with authorization check.

### DIFF
--- a/src/Middleware/AuthorizationMiddleware.php
+++ b/src/Middleware/AuthorizationMiddleware.php
@@ -111,12 +111,12 @@ class AuthorizationMiddleware
 
         try {
             $response = $next($request, $response);
+            if ($this->getConfig('requireAuthorizationCheck') && !$service->authorizationChecked()) {
+                throw new AuthorizationRequiredException(['url' => $request->getRequestTarget()]);
+            }
         } catch (Exception $exception) {
             $handler = $this->getHandler();
             $response = $handler->handle($exception, $request, $response, (array)$this->getConfig('unauthorizedHandler'));
-        }
-        if ($this->getConfig('requireAuthorizationCheck') && !$service->authorizationChecked()) {
-            throw new AuthorizationRequiredException(['url' => $request->getRequestTarget()]);
         }
 
         return $response;


### PR DESCRIPTION
Responses for unauthorized requests returned from handlers were not
returned by the middleware with authorization check enabled.

Authorization check has been moved to the `try` block so the authorization
check is made only when app does not throw any exception.