### PR TITLE
Docs updates & Property delegation

### DIFF
--- a/docs/Checking-Authorization.md
+++ b/docs/Checking-Authorization.md
@@ -34,6 +34,9 @@ $originalUser = $user->getOriginalData();
 ```
 
 You can pass the `$user` into your models, services or templates allowing you to
-check authorization anywhere in your application easily. You can use the
-[AuthorizationComponent](./Component.md) to automate
-authorization checks in your controller based on conventions.
+check authorization anywhere in your application easily. See the [identity
+decorator](./Middleware.md#identity-decorator) section for how to customize or
+replace the default decorator.
+
+The [AuthorizationComponent](./Component.md) can be used in controller actions
+to streamline authorization checks that raise exceptions on failure.

--- a/docs/Policies.md
+++ b/docs/Policies.md
@@ -68,11 +68,11 @@ class ArticlesPolicy
 ```
 
 
-### Policy Preconditions
+### Policy Pre-conditions
 
 In some policies you may wish to apply common checks across all operations in
 a policy. This is useful when you need to deny all actions to the provided
-resource. To use preconditions you need to implement the `BeforePolicyInterface`
+resource. To use pre-conditions you need to implement the `BeforePolicyInterface`
 in your policy:
 
 ```php

--- a/docs/Quick-start-and-introduction.md
+++ b/docs/Quick-start-and-introduction.md
@@ -31,6 +31,7 @@ use Authorization\Policy\OrmResolver;
 Then add the following to your `middleware()` method:
 
 ```php
+// Add authorization (after authentication if you are using that plugin too).
 $middleware->add(new AuthorizationMiddleware($this));
 ```
 
@@ -60,10 +61,22 @@ $this->loadComponent('Authorization.Authorization');
 ```
 
 By loading the [authorization component](./Component.php) we'll be able to check
-authorization on a per action basic more easily.
+authorization on a per action basic more easily. For example, we can do:
 
-You are now ready to start [creating policies](./Policies.md) and enforcing your
-authorization rules.
+```php
+public function edit($id)
+{
+    $article = $this->Article->get($id);
+    $this->Authorization->authorize('update', $article);
+
+    // Rest of action
+}
+```
+
+By calling `authorize` we can use our [policies](./Policies.md) to enforce our
+application's access control rules. You can check permissions anywhere by using
+the [identity stored in the request](./Checking-Authorization.md).
+
 
 ## Further Reading
 

--- a/docs/Quick-start-and-introduction.md
+++ b/docs/Quick-start-and-introduction.md
@@ -64,7 +64,7 @@ By loading the [authorization component](./Component.php) we'll be able to check
 authorization on a per action basic more easily. For example, we can do:
 
 ```php
-public function edit($id)
+public function edit($id = null)
 {
     $article = $this->Article->get($id);
     $this->Authorization->authorize('update', $article);

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -107,6 +107,28 @@ class IdentityDecorator implements IdentityInterface
     }
 
     /**
+     * Delegate property access to decorated identity.
+     *
+     * @param string $property The property to read.
+     * @return mixed
+     */
+    public function __get($property)
+    {
+        return $this->identity->{$property};
+    }
+
+    /**
+     * Delegate property isset to decorated identity.
+     *
+     * @param string $property The property to read.
+     * @return mixed
+     */
+    public function __isset($property)
+    {
+        return isset($this->identity->{$property});
+    }
+
+    /**
      * Whether a offset exists
      *
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php

--- a/tests/TestCase/IdentityDecoratorTest.php
+++ b/tests/TestCase/IdentityDecoratorTest.php
@@ -124,4 +124,17 @@ class IdentityDecoratorTest extends TestCase
         $identity = new IdentityDecorator($auth, $inner);
         $this->assertSame($data, $identity->getOriginalData());
     }
+
+    public function testGetProperty()
+    {
+        $data = new Article(['id' => 2]);
+        $auth = $this->createMock(AuthorizationServiceInterface::class);
+        $identity = new IdentityDecorator($auth, $data);
+
+        $this->assertTrue(isset($identity->id));
+        $this->assertSame($data->id, $identity->id);
+
+        $this->assertFalse(isset($identity->unknown));
+        $this->assertNull($identity->unknown);
+    }
 }


### PR DESCRIPTION
Improve docs  & add __get delegation

* Show how to replace the decorator.
* Give better links.
* Supporting `__get` and `__isset` helps smooth out decorator usage as not being able to read properties is a pain when moving from a basic entity. It is also inconsistent with ArrayAccess interface.