### PR TITLE
Allow null as identity for policies

### DIFF
--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -47,7 +47,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function can(IdentityInterface $user, $action, $resource)
+    public function can($user, $action, $resource)
     {
         $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);
@@ -72,7 +72,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function applyScope(IdentityInterface $user, $action, $resource)
+    public function applyScope($user, $action, $resource)
     {
         $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);

--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -25,12 +25,12 @@ interface AuthorizationServiceInterface
      * This method is intended to allow your application to build
      * conditional logic around authorization checks.
      *
-     * @param \Authorization\IdentityInterface $user The user to check permissions for.
+     * @param \Authorization\IdentityInterface|null $user The user to check permissions for.
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
      * @return bool
      */
-    public function can(IdentityInterface $user, $action, $resource);
+    public function can($user, $action, $resource);
 
     /**
      * Apply authorization scope conditions/restrictions.
@@ -40,12 +40,12 @@ interface AuthorizationServiceInterface
      * use case for scopes are restricting a query to only return records
      * visible to the current user.
      *
-     * @param \Authorization\IdentityInterface $user The user to check permissions for.
+     * @param \Authorization\IdentityInterface|null $user The user to check permissions for.
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
      * @return mixed The modified resource.
      */
-    public function applyScope(IdentityInterface $user, $action, $resource);
+    public function applyScope($user, $action, $resource);
 
     /**
      * Return a boolean based on whether or not this object

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -134,7 +134,7 @@ class AuthorizationComponent extends Component
      * Get the identity from a request.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request
-     * @return \Authorization\IdentityInterface
+     * @return \Authorization\IdentityInterface|null
      * @throws \Authorization\Exception\MissingIdentityException When identity is not present in a request.
      * @throws \InvalidArgumentException When invalid identity encountered.
      */
@@ -143,7 +143,7 @@ class AuthorizationComponent extends Component
         $identityAttribute = $this->getConfig('identityAttribute');
         $identity = $request->getAttribute($identityAttribute);
         if ($identity === null) {
-            throw new MissingIdentityException([$identityAttribute]);
+            return $identity;
         }
         if (!$identity instanceof IdentityInterface) {
             $type = is_object($identity) ? get_class($identity) : gettype($identity);

--- a/src/Policy/BeforePolicyInterface.php
+++ b/src/Policy/BeforePolicyInterface.php
@@ -29,10 +29,10 @@ interface BeforePolicyInterface
      * If a boolean value is returned, the action check will be skipped and pre-authorization
      * check result will be returned. In case of `null`, the action check will take place.
      *
-     * @param \Authorization\IdentityInterface $identity Identity object.
+     * @param \Authorization\IdentityInterface|null $identity Identity object.
      * @param mixed $resource The resource being operated on.
      * @param string $action The action/operation being performed.
      * @return bool|null
      */
-    public function before(IdentityInterface $identity, $resource, $action);
+    public function before($identity, $resource, $action);
 }

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -26,6 +26,23 @@ use TestApp\Policy\ArticlePolicy;
 
 class AuthorizationServiceTest extends TestCase
 {
+    public function testNullUserCan()
+    {
+        $resolver = new MapResolver([
+            Article::class => ArticlePolicy::class
+        ]);
+
+        $service = new AuthorizationService($resolver);
+
+        $user = null;
+
+        $result = $service->can($user, 'view', new Article);
+        $this->assertFalse($result);
+
+        $result = $service->can($user, 'view', new Article(['visibility' => 'public']));
+        $this->assertTrue($result);
+    }
+
     public function testCan()
     {
         $resolver = new MapResolver([

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -189,19 +189,6 @@ class AuthorizationComponentTest extends TestCase
         $this->Auth->authorize($article);
     }
 
-    public function testAuthorizeMissingIdentity()
-    {
-        $this->expectException(MissingIdentityException::class);
-        $this->expectExceptionCode(403);
-        $this->expectExceptionMessage('Identity is not present in `identity` request attribute.');
-
-        $this->Controller->request = $this->Controller->request
-            ->withoutAttribute('identity');
-
-        $article = new Article(['user_id' => 1]);
-        $this->Auth->authorize($article);
-    }
-
     public function testAuthorizeModelSuccess()
     {
         $service = new AuthorizationService(new OrmResolver());

--- a/tests/test_app/TestApp/Policy/ArticlePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlePolicy.php
@@ -64,4 +64,22 @@ class ArticlePolicy
 
         return $article;
     }
+
+    /**
+     * Testing that the article can be viewed if its public and no user is logged in
+     *
+     * This test "null" user cases
+     *
+     * @param \Authorization\IdentityInterface $user
+     * @param Article $article
+     * @return bool
+     */
+    public function canView($user, Article $article)
+    {
+        if ($article->get('visibility') !== 'public' && empty($user)) {
+            return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
Policies can handle non-logged in cases then as well. I've had a discussion with @markstory about this and by removing the requirement of an identity object we can deny or allow access for non-logged cases as well by a policy.