### PR TITLE
Catch certain exceptions in the component's can function and return false instead

### DIFF
--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -122,7 +122,7 @@ class AuthorizationComponent extends Component
     {
         $request = $this->getController()->request;
         $identity = $this->getIdentity($request);
-        if (empty($identity) && $this->getService($this->request)->can(null, $action, $resource)) {
+        if (empty($identity) && $this->getService($request)->can(null, $action, $resource)) {
             return true;
         }
 

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -140,6 +140,14 @@ class AuthorizationComponentTest extends TestCase
         $this->Auth->authorize('ArticlesTable');
     }
 
+    public function testAuthorizePolicyException()
+    {
+        $this->expectException(MissingIdentityException::class);
+
+        $article = new Article(['user_id' => 99]);
+        $this->Auth->authorize($article, 'exception');
+    }
+
     public function testAuthorizeSuccessCheckImplicitAction()
     {
         $article = new Article(['user_id' => 1]);
@@ -425,5 +433,7 @@ class AuthorizationComponentTest extends TestCase
         $article = new Article(['user_id' => 2]);
         $this->assertFalse($this->Auth->can($article));
         $this->assertFalse($this->Auth->can($article, 'delete'));
+
+        $this->assertFalse($this->Auth->can($article, 'exception'));
     }
 }

--- a/tests/test_app/TestApp/Policy/ArticlePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlePolicy.php
@@ -82,4 +82,17 @@ class ArticlePolicy
 
         return true;
     }
+
+    /**
+     * Testing that exceptions are properly handled
+     *
+     * @param \Authorization\IdentityInterface|null $user
+     * @param Article $article
+     * @return bool
+     * @throws \Authorization\Exception\MissingIdentityException
+     */
+    public function canException($user, Article $article)
+    {
+        throw new \Authorization\Exception\MissingIdentityException();
+    }
 }


### PR DESCRIPTION
This addresses part of issue #62. Note that the *service*'s `can` function has not been changed, only the *component*'s. We do want exceptions thrown from policies to get through the `authorize` function. If we want to change the service's `can` function to catch exceptions, then we might create a new `authorize` function in there as well, which the component can call, or add a parameter indicating whether or not exceptions should be caught.