### PR TITLE
Add policy check Result object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then vendor/bin/phpunit; fi
 
   - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/; fi
-  - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -l 4 src; fi
+  - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -c phpstan.neon -l 4 src; fi
 
 after_success:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+    ignoreErrors:
+        - '#Casting to [a-z]+ something that.s already [a-z]+.#'

--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -28,7 +28,7 @@ interface AuthorizationServiceInterface
      * @param \Authorization\IdentityInterface|null $user The user to check permissions for.
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
-     * @return bool
+     * @return bool|\Authorization\Policy\ResultInterface
      */
     public function can($user, $action, $resource);
 

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -15,6 +15,8 @@
 
 namespace Authorization\Exception;
 
+use Authorization\Policy\ResultInterface;
+
 class ForbiddenException extends Exception
 {
     /**
@@ -26,4 +28,42 @@ class ForbiddenException extends Exception
      * {@inheritDoc}
      */
     protected $_messageTemplate = 'Identity is not authorized to perform `%s` on `%s`.';
+
+    /**
+     * Policy check result.
+     *
+     * @var \Authorization\Policy\ResultInterface|null
+     */
+    protected $result;
+
+    /**
+     * Constructor
+     *
+     * @param ResultInterface|null $result Policy check result.
+     * @param string|array $message Either the string of the error message, or an array of attributes
+     *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
+     * @param int|null $code The code of the error, is also the HTTP status code for the error.
+     * @param \Exception|null $previous the previous exception.
+     */
+    public function __construct($result = null, $message = '', $code = null, $previous = null)
+    {
+        if ($result instanceof ResultInterface) {
+            $this->result = $result;
+
+            parent::__construct($message, $code, $previous);
+        } else {
+            //shift off first argument fort BC
+            parent::__construct($result, $message, $code);
+        }
+    }
+
+    /**
+     * Returns policy check result if passed to the exception.
+     *
+     * @return \Authorization\Policy\ResultInterface|null
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
 }

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -52,7 +52,7 @@ class ForbiddenException extends Exception
 
             parent::__construct($message, $code, $previous);
         } else {
-            //shift off first argument fort BC
+            //shift off first argument for BC
             parent::__construct($result, $message, $code);
         }
     }

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -30,7 +30,7 @@ interface IdentityInterface extends ArrayAccess
      *
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
-     * @return bool
+     * @return bool|\Authorization\Policy\ResultInterface
      */
     public function can($action, $resource);
 

--- a/src/Middleware/RequestAuthorizationMiddleware.php
+++ b/src/Middleware/RequestAuthorizationMiddleware.php
@@ -94,11 +94,11 @@ class RequestAuthorizationMiddleware
         $service = $this->getServiceFromRequest($request);
         $identity = $request->getAttribute($this->getConfig('identityAttribute'));
 
-        $result = !$service->can($identity, $this->getConfig('method'), $request);
+        $result = $service->can($identity, $this->getConfig('method'), $request);
         if (!$result instanceof ResultInterface) {
             $result = new Result($result);
         }
-        if ($result->getStatus()) {
+        if (!$result->getStatus()) {
             throw new ForbiddenException($result);
         }
 

--- a/src/Policy/BeforePolicyInterface.php
+++ b/src/Policy/BeforePolicyInterface.php
@@ -14,8 +14,6 @@
  */
 namespace Authorization\Policy;
 
-use Authorization\IdentityInterface;
-
 /**
  * This interface should be implemented if a policy class needs to perform a
  * pre-authorization check before the action access check takes place.
@@ -32,7 +30,7 @@ interface BeforePolicyInterface
      * @param \Authorization\IdentityInterface|null $identity Identity object.
      * @param mixed $resource The resource being operated on.
      * @param string $action The action/operation being performed.
-     * @return bool|null
+     * @return \Authorization\Policy\ResultInterface|bool|null
      */
     public function before($identity, $resource, $action);
 }

--- a/src/Policy/Result.php
+++ b/src/Policy/Result.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authorization\Policy;
+
+/**
+ * Policy check result
+ */
+class Result implements ResultInterface
+{
+    /**
+     * Check status.
+     *
+     * @var bool
+     */
+    protected $status;
+
+    /**
+     * Failure reason.
+     *
+     * @var string|null
+     */
+    protected $reason;
+
+    /**
+     * Constructor
+     *
+     * @param bool $status Check status.
+     * @param string|null $reason Failure reason.
+     */
+    public function __construct($status, $reason = null)
+    {
+        $this->status = (bool)$status;
+        if ($reason !== null) {
+            $this->reason = (string)$reason;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReason()
+    {
+        return $this->reason;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+}

--- a/src/Policy/ResultInterface.php
+++ b/src/Policy/ResultInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authorization\Policy;
+
+/**
+ * Policy check result interface
+ */
+interface ResultInterface
+{
+    /**
+     * Returns policy check status.
+     *
+     * @return bool
+     */
+    public function getStatus();
+
+    /**
+     * Optional reason why policy check has failed.
+     *
+     * @return string|null
+     */
+    public function getReason();
+}

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -273,7 +273,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Pre-authorization check must return `bool` or `null`.');
+        $this->expectExceptionMessage('Pre-authorization check must return `Authorization\Policy\ResultInterface`, `bool` or `null`.');
 
         $service->can($user, 'add', $entity);
     }

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -19,6 +19,8 @@ use Authorization\IdentityDecorator;
 use Authorization\Policy\BeforePolicyInterface;
 use Authorization\Policy\Exception\MissingMethodException;
 use Authorization\Policy\MapResolver;
+use Authorization\Policy\Result;
+use Authorization\Policy\ResultInterface;
 use Cake\TestSuite\TestCase;
 use RuntimeException;
 use TestApp\Model\Entity\Article;
@@ -244,6 +246,68 @@ class AuthorizationServiceTest extends TestCase
 
         $result = $service->can($user, 'add', $entity);
         $this->assertTrue($result);
+    }
+
+    public function testBeforeResultTrue()
+    {
+        $entity = new Article();
+
+        $policy = $this->getMockBuilder(BeforePolicyInterface::class)
+            ->setMethods(['before', 'canAdd'])
+            ->getMock();
+
+        $policy->expects($this->once())
+            ->method('before')
+            ->with($this->isInstanceOf(IdentityDecorator::class), $entity, 'add')
+            ->willReturn(new Result(true));
+
+        $policy->expects($this->never())
+            ->method('canAdd');
+
+        $resolver = new MapResolver([
+            Article::class => $policy
+        ]);
+
+        $service = new AuthorizationService($resolver);
+
+        $user = new IdentityDecorator($service, [
+            'role' => 'admin'
+        ]);
+
+        $result = $service->can($user, 'add', $entity);
+        $this->assertInstanceOf(ResultInterface::class, $result);
+        $this->assertTrue($result->getStatus());
+    }
+
+    public function testBeforeResultFalse()
+    {
+        $entity = new Article();
+
+        $policy = $this->getMockBuilder(BeforePolicyInterface::class)
+            ->setMethods(['before', 'canAdd'])
+            ->getMock();
+
+        $policy->expects($this->once())
+            ->method('before')
+            ->with($this->isInstanceOf(IdentityDecorator::class), $entity, 'add')
+            ->willReturn(new Result(false));
+
+        $policy->expects($this->never())
+            ->method('canAdd');
+
+        $resolver = new MapResolver([
+            Article::class => $policy
+        ]);
+
+        $service = new AuthorizationService($resolver);
+
+        $user = new IdentityDecorator($service, [
+            'role' => 'admin'
+        ]);
+
+        $result = $service->can($user, 'add', $entity);
+        $this->assertInstanceOf(ResultInterface::class, $result);
+        $this->assertFalse($result->getStatus());
     }
 
     public function testBeforeOther()

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -62,6 +62,22 @@ class AuthorizationServiceTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testCanWithResult()
+    {
+        $resolver = new MapResolver([
+            Article::class => ArticlePolicy::class
+        ]);
+
+        $service = new AuthorizationService($resolver);
+
+        $user = new IdentityDecorator($service, [
+            'role' => 'admin'
+        ]);
+
+        $result = $service->can($user, 'publish', new Article);
+        $this->assertInstanceOf(ResultInterface::class, $result);
+    }
+
     public function testAuthorizationCheckedWithCan()
     {
         $resolver = new MapResolver([

--- a/tests/test_app/TestApp/Policy/ArticlePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlePolicy.php
@@ -1,6 +1,7 @@
 <?php
 namespace TestApp\Policy;
 
+use Authorization\Policy\Result;
 use TestApp\Model\Entity\Article;
 
 class ArticlePolicy
@@ -81,5 +82,23 @@ class ArticlePolicy
         }
 
         return true;
+    }
+
+    /**
+     * Testing that the article can be published
+     *
+     * This tests Result objects.
+     *
+     * @param \Authorization\IdentityInterface|null $user
+     * @param Article $article
+     * @return Result
+     */
+    public function canPublish($user, Article $article)
+    {
+        if ($article->get('visibility') === 'public') {
+            return new Result(false, 'public');
+        }
+
+        return new Result($article->get('user_id') === $user['id']);
     }
 }

--- a/tests/test_app/TestApp/Policy/RequestPolicy.php
+++ b/tests/test_app/TestApp/Policy/RequestPolicy.php
@@ -1,6 +1,7 @@
 <?php
 namespace TestApp\Policy;
 
+use Authorization\Policy\Result;
 use Cake\Http\ServerRequest;
 
 /**
@@ -24,5 +25,23 @@ class RequestPolicy
         }
 
         return false;
+    }
+
+    /**
+     * Method to check if the request can be accessed
+     *
+     * @param null|\Authorization\IdentityInterface Identity
+     * @param \Cake\Http\ServerRequest $request Request
+     * @return \Authorization\Policy\ResultInterface
+     */
+    public function canEnter($identity, ServerRequest $request)
+    {
+        if ($request->getParam('controller') === 'Articles'
+            && $request->getParam('action') === 'index'
+        ) {
+            return new Result(true);
+        }
+
+        return new Result(false, 'wrong action');
     }
 }


### PR DESCRIPTION
Refs discussions: https://github.com/cakephp/authorization/issues/62 https://github.com/cakephp/authorization/pull/63 

This allows policies to return result objects that wrap status boolean and a reason string. Policies can still return just bools so this change should be transparent to those who don't use the new result object.

No tests added yet, as I'm not 100% sure this is a good solution to the problems pointed out in issues linked above.