### PR TITLE
2.x More types

### DIFF
--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -49,7 +49,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function can(?IdentityInterface $user, $action, $resource)
+    public function can(?IdentityInterface $user, string $action, $resource)
     {
         $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);
@@ -82,7 +82,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function applyScope(?IdentityInterface $user, $action, $resource)
+    public function applyScope(?IdentityInterface $user, string $action, $resource)
     {
         $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);

--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -49,7 +49,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function can($user, $action, $resource)
+    public function can(?IdentityInterface $user, $action, $resource)
     {
         $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);
@@ -82,7 +82,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function applyScope($user, $action, $resource)
+    public function applyScope(?IdentityInterface $user, $action, $resource)
     {
         $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);

--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -99,7 +99,7 @@ class AuthorizationService implements AuthorizationServiceInterface
      * @return callable
      * @throws \Authorization\Policy\Exception\MissingMethodException
      */
-    protected function getCanHandler($policy, $action)
+    protected function getCanHandler($policy, $action): callable
     {
         $method = 'can' . ucfirst($action);
 
@@ -118,7 +118,7 @@ class AuthorizationService implements AuthorizationServiceInterface
      * @return callable
      * @throws \Authorization\Policy\Exception\MissingMethodException
      */
-    protected function getScopeHandler($policy, $action)
+    protected function getScopeHandler($policy, $action): callable
     {
         $method = 'scope' . ucfirst($action);
 
@@ -132,7 +132,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function authorizationChecked()
+    public function authorizationChecked(): bool
     {
         return $this->authorizationChecked;
     }

--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -31,7 +31,7 @@ interface AuthorizationServiceInterface
      * @param mixed $resource The resource being operated on.
      * @return bool|\Authorization\Policy\ResultInterface
      */
-    public function can($user, $action, $resource);
+    public function can(?IdentityInterface $user, string $action, $resource);
 
     /**
      * Apply authorization scope conditions/restrictions.
@@ -46,7 +46,7 @@ interface AuthorizationServiceInterface
      * @param mixed $resource The resource being operated on.
      * @return mixed The modified resource.
      */
-    public function applyScope($user, $action, $resource);
+    public function applyScope(?IdentityInterface $user, string $action, $resource);
 
     /**
      * Return a boolean based on whether or not this object
@@ -54,7 +54,7 @@ interface AuthorizationServiceInterface
      *
      * @return bool
      */
-    public function authorizationChecked();
+    public function authorizationChecked(): bool;
 
     /**
      * Allow for authorization to be skipped for this object.

--- a/src/AuthorizationServiceProviderInterface.php
+++ b/src/AuthorizationServiceProviderInterface.php
@@ -30,5 +30,8 @@ interface AuthorizationServiceProviderInterface
      * @param \Psr\Http\Message\ResponseInterface $response Response
      * @return \Authorization\AuthorizationServiceInterface
      */
-    public function getAuthorizationService(ServerRequestInterface $request, ResponseInterface $response);
+    public function getAuthorizationService(
+        ServerRequestInterface $request,
+        ResponseInterface $response
+    ): AuthorizationServiceInterface;
 }

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -116,11 +116,11 @@ class AuthorizationComponent extends Component
      * If $action is left undefined, the current controller action will
      * be used.
      *
-     * @param object $resource The resource to apply a scope to.
+     * @param mixed $resource The resource to apply a scope to.
      * @param string|null $action The action to apply a scope for.
-     * @return object
+     * @return mixed
      */
-    public function applyScope(object $resource, ?string $action = null): object
+    public function applyScope($resource, ?string $action = null)
     {
         $request = $this->getController()->getRequest();
         if ($action === null) {

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -55,12 +55,12 @@ class AuthorizationComponent extends Component
      * If $action is left undefined, the current controller action will
      * be used.
      *
-     * @param object $resource The resource to check authorization on.
+     * @param mixed $resource The resource to check authorization on.
      * @param string|null $action The action to check authorization for.
      * @return void
      * @throws \Authorization\Exception\ForbiddenException when policy check fails.
      */
-    public function authorize($resource, $action = null)
+    public function authorize($resource, ?string $action = null): void
     {
         if ($action === null) {
             $request = $this->getController()->getRequest();
@@ -91,11 +91,11 @@ class AuthorizationComponent extends Component
      * If $action is left undefined, the current controller action will
      * be used.
      *
-     * @param object $resource The resource to check authorization on.
+     * @param mixed $resource The resource to check authorization on.
      * @param string|null $action The action to check authorization for.
      * @return bool|\Authorization\Policy\ResultInterface
      */
-    public function can($resource, $action = null)
+    public function can($resource, ?string $action = null)
     {
         $request = $this->getController()->getRequest();
         if ($action === null) {
@@ -120,7 +120,7 @@ class AuthorizationComponent extends Component
      * @param string|null $action The action to apply a scope for.
      * @return object
      */
-    public function applyScope($resource, $action = null)
+    public function applyScope(object $resource, ?string $action = null): object
     {
         $request = $this->getController()->getRequest();
         if ($action === null) {
@@ -153,7 +153,7 @@ class AuthorizationComponent extends Component
      * @return \Authorization\AuthorizationServiceInterface
      * @throws \InvalidArgumentException When invalid authorization service encountered.
      */
-    protected function getService(ServerRequestInterface $request)
+    protected function getService(ServerRequestInterface $request): \Authorization\AuthorizationServiceInterface
     {
         $serviceAttribute = $this->getConfig('serviceAttribute');
         $service = $request->getAttribute($serviceAttribute);
@@ -178,7 +178,7 @@ class AuthorizationComponent extends Component
      * @throws \Authorization\Exception\MissingIdentityException When identity is not present in a request.
      * @throws \InvalidArgumentException When invalid identity encountered.
      */
-    protected function getIdentity(ServerRequestInterface $request)
+    protected function getIdentity(ServerRequestInterface $request): ?IdentityInterface
     {
         $identityAttribute = $this->getConfig('identityAttribute');
         $identity = $request->getAttribute($identityAttribute);
@@ -205,7 +205,7 @@ class AuthorizationComponent extends Component
      *
      * @return void
      */
-    public function authorizeAction()
+    public function authorizeAction(): void
     {
         $request = $this->getController()->getRequest();
         $action = $request->getParam('action');
@@ -230,7 +230,7 @@ class AuthorizationComponent extends Component
      * @param string $configKey Configuration key with actions.
      * @return bool
      */
-    protected function checkAction($action, $configKey)
+    protected function checkAction(string $action, string $configKey): bool
     {
         $actions = (array)$this->getConfig($configKey);
 
@@ -244,7 +244,7 @@ class AuthorizationComponent extends Component
      * @return string
      * @throws \UnexpectedValueException When invalid action type encountered.
      */
-    protected function getDefaultAction(ServerRequest $request)
+    protected function getDefaultAction(ServerRequest $request): string
     {
         $action = $request->getParam('action');
         $name = $this->getConfig('actionMap.' . $action);

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
  * @since         1.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Authorization\Exception;
 
 use Authorization\Policy\ResultInterface;
@@ -46,7 +45,7 @@ class ForbiddenException extends Exception
      * @param int|null $code The code of the error, is also the HTTP status code for the error.
      * @param \Exception|null $previous the previous exception.
      */
-    public function __construct($result = null, $message = '', $code = null, $previous = null)
+    public function __construct(?ResultInterface $result = null, $message = '', $code = null, $previous = null)
     {
         if ($result instanceof ResultInterface) {
             $this->result = $result;
@@ -63,7 +62,7 @@ class ForbiddenException extends Exception
      *
      * @return \Authorization\Policy\ResultInterface|null
      */
-    public function getResult()
+    public function getResult(): ?ResultInterface
     {
         return $this->result;
     }

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -100,7 +100,7 @@ class IdentityDecorator implements IdentityInterface
      * @param array $args The arguments for the method.
      * @return mixed
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         if (!is_object($this->identity)) {
             throw new BadMethodCallException("Cannot call `{$method}`. Identity data is not an object.");
@@ -116,7 +116,7 @@ class IdentityDecorator implements IdentityInterface
      * @param string $property The property to read.
      * @return mixed
      */
-    public function __get($property)
+    public function __get(string $property)
     {
         return $this->identity->{$property};
     }
@@ -127,7 +127,7 @@ class IdentityDecorator implements IdentityInterface
      * @param string $property The property to read.
      * @return mixed
      */
-    public function __isset($property)
+    public function __isset(string $property)
     {
         return isset($this->identity->{$property});
     }
@@ -139,7 +139,7 @@ class IdentityDecorator implements IdentityInterface
      * @param mixed $offset Offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->identity[$offset]);
     }
@@ -180,7 +180,7 @@ class IdentityDecorator implements IdentityInterface
      * @param mixed $offset Offset
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->identity[$offset]);
     }

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -68,7 +68,7 @@ class IdentityDecorator implements IdentityInterface
     /**
      * {@inheritDoc}
      */
-    public function can($action, $resource)
+    public function can(string $action, $resource)
     {
         return $this->authorization->can($this, $action, $resource);
     }
@@ -76,7 +76,7 @@ class IdentityDecorator implements IdentityInterface
     /**
      * {@inheritDoc}
      */
-    public function applyScope($action, $resource)
+    public function applyScope(string $action, $resource)
     {
         return $this->authorization->applyScope($this, $action, $resource);
     }

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -33,7 +33,7 @@ interface IdentityInterface extends ArrayAccess
      * @param mixed $resource The resource being operated on.
      * @return bool|\Authorization\Policy\ResultInterface
      */
-    public function can($action, $resource);
+    public function can(string $action, $resource);
 
     /**
      * Apply authorization scope conditions/restrictions.
@@ -42,7 +42,7 @@ interface IdentityInterface extends ArrayAccess
      * @param mixed $resource The resource being operated on.
      * @return mixed The modified resource.
      */
-    public function applyScope($action, $resource);
+    public function applyScope(string $action, $resource);
 
     /**
      * Get the decorated identity

--- a/src/Middleware/AuthorizationMiddleware.php
+++ b/src/Middleware/AuthorizationMiddleware.php
@@ -99,8 +99,11 @@ class AuthorizationMiddleware
      * @param callable $next The next middleware to call.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
         $service = $this->getAuthorizationService($request, $response);
         $request = $request->withAttribute('authorization', $service);
 
@@ -135,7 +138,7 @@ class AuthorizationMiddleware
      *
      * @return \Authorization\Middleware\UnauthorizedHandler\HandlerInterface
      */
-    protected function getHandler()
+    protected function getHandler(): \Authorization\Middleware\UnauthorizedHandler\HandlerInterface
     {
         $handler = $this->getConfig('unauthorizedHandler');
         if (!is_array($handler)) {
@@ -158,8 +161,10 @@ class AuthorizationMiddleware
      * @return \Authorization\AuthorizationServiceInterface
      * @throws \RuntimeException When authorization method has not been defined.
      */
-    protected function getAuthorizationService($request, $response)
-    {
+    protected function getAuthorizationService(
+        ServerRequestInterface $request,
+        ResponseInterface $response
+    ): AuthorizationServiceInterface {
         $service = $this->subject;
         if ($this->subject instanceof AuthorizationServiceProviderInterface) {
             $service = $this->subject->getAuthorizationService($request, $response);
@@ -183,7 +188,7 @@ class AuthorizationMiddleware
      * @param \ArrayAccess|array $identity Identity data
      * @return \Authorization\IdentityInterface
      */
-    protected function buildIdentity(AuthorizationServiceInterface $service, $identity)
+    protected function buildIdentity(AuthorizationServiceInterface $service, $identity): IdentityInterface
     {
         $class = $this->getConfig('identityDecorator');
 

--- a/src/Middleware/RequestAuthorizationMiddleware.php
+++ b/src/Middleware/RequestAuthorizationMiddleware.php
@@ -54,7 +54,7 @@ class RequestAuthorizationMiddleware
      *
      * @param array $config Configuration options
      */
-    public function __construct($config = [])
+    public function __construct(array $config = [])
     {
         $this->setConfig($config);
     }
@@ -65,7 +65,7 @@ class RequestAuthorizationMiddleware
      * @param \Psr\Http\Message\ServerRequestInterface $request Server request.
      * @return \Authorization\AuthorizationServiceInterface
      */
-    protected function getServiceFromRequest(ServerRequestInterface $request)
+    protected function getServiceFromRequest(ServerRequestInterface $request): AuthorizationServiceInterface
     {
         $serviceAttribute = $this->getConfig('authorizationAttribute');
         $service = $request->getAttribute($serviceAttribute);
@@ -89,8 +89,11 @@ class RequestAuthorizationMiddleware
      * @param callable $next The next middleware to call.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
         $service = $this->getServiceFromRequest($request);
         $identity = $request->getAttribute($this->getConfig('identityAttribute'));
 

--- a/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php
@@ -63,7 +63,7 @@ class CakeRedirectHandler extends RedirectHandler
     /**
      * {@inheritDoc}
      */
-    protected function getUrl(ServerRequestInterface $request, array $options)
+    protected function getUrl(ServerRequestInterface $request, array $options): string
     {
         $url = $options['url'];
         if ($options['queryParam'] !== null) {

--- a/src/Middleware/UnauthorizedHandler/ExceptionHandler.php
+++ b/src/Middleware/UnauthorizedHandler/ExceptionHandler.php
@@ -32,7 +32,7 @@ class ExceptionHandler implements HandlerInterface
         ServerRequestInterface $request,
         ResponseInterface $response,
         array $options = []
-    ) {
+    ): ResponseInterface {
         throw $exception;
     }
 }

--- a/src/Middleware/UnauthorizedHandler/HandlerFactory.php
+++ b/src/Middleware/UnauthorizedHandler/HandlerFactory.php
@@ -30,7 +30,7 @@ class HandlerFactory
      * @return \Authorization\Middleware\UnauthorizedHandler\HandlerInterface
      * @throws \RuntimeException When invalid handler encountered.
      */
-    public static function create($name)
+    public static function create(string $name): HandlerInterface
     {
         $class = App::className($name, 'Middleware/UnauthorizedHandler', 'Handler');
         if (!$class) {

--- a/src/Middleware/UnauthorizedHandler/HandlerInterface.php
+++ b/src/Middleware/UnauthorizedHandler/HandlerInterface.php
@@ -38,5 +38,5 @@ interface HandlerInterface
         ServerRequestInterface $request,
         ResponseInterface $response,
         array $options = []
-    );
+    ): ResponseInterface;
 }

--- a/src/Middleware/UnauthorizedHandler/RedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/RedirectHandler.php
@@ -54,7 +54,7 @@ class RedirectHandler implements HandlerInterface
         ServerRequestInterface $request,
         ResponseInterface $response,
         array $options = []
-    ) {
+    ): ResponseInterface {
         $options += $this->defaultOptions;
 
         if (!$this->checkException($exception, $options['exceptions'])) {
@@ -75,7 +75,7 @@ class RedirectHandler implements HandlerInterface
      * @param array $exceptions A list of exception classes.
      * @return bool
      */
-    protected function checkException(Exception $exception, array $exceptions)
+    protected function checkException(Exception $exception, array $exceptions): bool
     {
         foreach ($exceptions as $class) {
             if ($exception instanceof $class) {
@@ -93,7 +93,7 @@ class RedirectHandler implements HandlerInterface
      * @param array $options Options.
      * @return string
      */
-    protected function getUrl(ServerRequestInterface $request, array $options)
+    protected function getUrl(ServerRequestInterface $request, array $options): string
     {
         $url = $options['url'];
         if ($options['queryParam'] !== null && $request->getMethod() === 'GET') {

--- a/src/Policy/BeforePolicyInterface.php
+++ b/src/Policy/BeforePolicyInterface.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace Authorization\Policy;
 
+use Authorization\IdentityInterface;
+
 /**
  * This interface should be implemented if a policy class needs to perform a
  * pre-authorization check before the action access check takes place.
@@ -32,5 +34,5 @@ interface BeforePolicyInterface
      * @param string $action The action/operation being performed.
      * @return \Authorization\Policy\ResultInterface|bool|null
      */
-    public function before($identity, $resource, $action);
+    public function before(?IdentityInterface $identity, $resource, $action);
 }

--- a/src/Policy/MapResolver.php
+++ b/src/Policy/MapResolver.php
@@ -60,7 +60,7 @@ class MapResolver implements ResolverInterface
      * @return $this
      * @throws \InvalidArgumentException When a resource class does not exist or policy is invalid.
      */
-    public function map($resourceClass, $policy)
+    public function map(string $resourceClass, $policy)
     {
         if (!class_exists($resourceClass)) {
             $message = sprintf('Resource class `%s` does not exist.', $resourceClass);

--- a/src/Policy/OrmResolver.php
+++ b/src/Policy/OrmResolver.php
@@ -47,7 +47,7 @@ class OrmResolver implements ResolverInterface
      * @param string $appNamespace The application namespace
      * @param array<string, string> $overrides A list of plugin name overrides.
      */
-    public function __construct($appNamespace = 'App', array $overrides = [])
+    public function __construct(string $appNamespace = 'App', array $overrides = [])
     {
         $this->appNamespace = $appNamespace;
         $this->overrides = $overrides;
@@ -61,7 +61,7 @@ class OrmResolver implements ResolverInterface
      * @throws \Authorization\Policy\Exception\MissingPolicyException When a policy for the
      *   resource has not been defined or cannot be resolved.
      */
-    public function getPolicy($resource)
+    public function getPolicy($resource): object
     {
         if ($resource instanceof EntityInterface) {
             return $this->getEntityPolicy($resource);
@@ -82,7 +82,7 @@ class OrmResolver implements ResolverInterface
      * @param \Cake\Datasource\EntityInterface $entity The entity to get a policy for
      * @return object
      */
-    protected function getEntityPolicy(EntityInterface $entity)
+    protected function getEntityPolicy(EntityInterface $entity): object
     {
         $class = get_class($entity);
         $entityNamespace = '\Model\Entity\\';
@@ -98,7 +98,7 @@ class OrmResolver implements ResolverInterface
      * @param \Cake\Datasource\RepositoryInterface $table The table/repository to get a policy for.
      * @return object
      */
-    protected function getRepositoryPolicy(RepositoryInterface $table)
+    protected function getRepositoryPolicy(RepositoryInterface $table): object
     {
         $class = get_class($table);
         $tableNamespace = '\Model\Table\\';
@@ -118,7 +118,7 @@ class OrmResolver implements ResolverInterface
      *   resource has not been defined.
      * @return object
      */
-    protected function findPolicy($class, $name, $namespace)
+    protected function findPolicy(string $class, string $name, string $namespace): object
     {
         $namespace = $this->getNamespace($namespace);
         $policyClass = null;
@@ -146,7 +146,7 @@ class OrmResolver implements ResolverInterface
      * @param string $namespace The namespace to find the policy in.
      * @return string
      */
-    protected function getNamespace($namespace)
+    protected function getNamespace(string $namespace): string
     {
         if (isset($this->overrides[$namespace])) {
             return $this->overrides[$namespace];

--- a/src/Policy/OrmResolver.php
+++ b/src/Policy/OrmResolver.php
@@ -57,11 +57,11 @@ class OrmResolver implements ResolverInterface
      * Get a policy for an ORM Table, Entity or Query.
      *
      * @param \Cake\Datasource\RepositoryInterface|\Cake\Datasource\EntityInterface|\Cake\Datasource\QueryInterface $resource The resource.
-     * @return object
+     * @return mixed
      * @throws \Authorization\Policy\Exception\MissingPolicyException When a policy for the
      *   resource has not been defined or cannot be resolved.
      */
-    public function getPolicy($resource): object
+    public function getPolicy($resource)
     {
         if ($resource instanceof EntityInterface) {
             return $this->getEntityPolicy($resource);
@@ -80,9 +80,9 @@ class OrmResolver implements ResolverInterface
      * Get a policy for an entity
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity to get a policy for
-     * @return object
+     * @return mixed
      */
-    protected function getEntityPolicy(EntityInterface $entity): object
+    protected function getEntityPolicy(EntityInterface $entity)
     {
         $class = get_class($entity);
         $entityNamespace = '\Model\Entity\\';
@@ -96,9 +96,9 @@ class OrmResolver implements ResolverInterface
      * Get a policy for a table
      *
      * @param \Cake\Datasource\RepositoryInterface $table The table/repository to get a policy for.
-     * @return object
+     * @return mixed
      */
-    protected function getRepositoryPolicy(RepositoryInterface $table): object
+    protected function getRepositoryPolicy(RepositoryInterface $table)
     {
         $class = get_class($table);
         $tableNamespace = '\Model\Table\\';
@@ -116,9 +116,9 @@ class OrmResolver implements ResolverInterface
      * @param string $namespace The namespace to find the policy in.
      * @throws \Authorization\Policy\Exception\MissingPolicyException When a policy for the
      *   resource has not been defined.
-     * @return object
+     * @return mixed
      */
-    protected function findPolicy(string $class, string $name, string $namespace): object
+    protected function findPolicy(string $class, string $name, string $namespace)
     {
         $namespace = $this->getNamespace($namespace);
         $policyClass = null;

--- a/src/Policy/RequestPolicyInterface.php
+++ b/src/Policy/RequestPolicyInterface.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Authorization\Policy;
 
+use Authorization\IdentityInterface;
 use Cake\Http\ServerRequest;
 
 /**
@@ -27,7 +28,7 @@ interface RequestPolicyInterface
      *
      * @param \Authorization\IdentityInterface|null $identity Identity
      * @param \Cake\Http\ServerRequest $request Server Request
-     * @return bool
+     * @return bool|\Authorization\Policy\ResultInterface
      */
-    public function canAccess($identity, ServerRequest $request);
+    public function canAccess(?IdentityInterface $identity, ServerRequest $request);
 }

--- a/src/Policy/ResolverInterface.php
+++ b/src/Policy/ResolverInterface.php
@@ -27,7 +27,7 @@ interface ResolverInterface
      * exception if a policy cannot be resolved for a given resource.
      *
      * @param mixed $resource A resource that the access is checked against.
-     * @return object
+     * @return mixed
      * @throws \Authorization\Policy\Exception\MissingPolicyException If a policy cannot be resolved.
      */
     public function getPolicy($resource);

--- a/src/Policy/Result.php
+++ b/src/Policy/Result.php
@@ -40,7 +40,7 @@ class Result implements ResultInterface
      * @param bool $status Check status.
      * @param string|null $reason Failure reason.
      */
-    public function __construct($status, $reason = null)
+    public function __construct(bool $status, ?string $reason = null)
     {
         $this->status = (bool)$status;
         if ($reason !== null) {
@@ -51,7 +51,7 @@ class Result implements ResultInterface
     /**
      * {@inheritDoc}
      */
-    public function getReason()
+    public function getReason(): ?string
     {
         return $this->reason;
     }
@@ -59,7 +59,7 @@ class Result implements ResultInterface
     /**
      * {@inheritDoc}
      */
-    public function getStatus()
+    public function getStatus(): bool
     {
         return $this->status;
     }

--- a/src/Policy/ResultInterface.php
+++ b/src/Policy/ResultInterface.php
@@ -25,12 +25,12 @@ interface ResultInterface
      *
      * @return bool
      */
-    public function getStatus();
+    public function getStatus(): bool;
 
     /**
      * Optional reason why policy check has failed.
      *
      * @return string|null
      */
-    public function getReason();
+    public function getReason(): ?string;
 }

--- a/tests/test_app/TestApp/Middleware/UnauthorizedHandler/SuppressHandler.php
+++ b/tests/test_app/TestApp/Middleware/UnauthorizedHandler/SuppressHandler.php
@@ -22,8 +22,15 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class SuppressHandler implements HandlerInterface
 {
-    public function handle(Exception $exception, ServerRequestInterface $request, ResponseInterface $response, array $options = [])
-    {
+    /**
+     * @inheritDoc
+     */
+    public function handle(
+        Exception $exception,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $options = []
+    ): ResponseInterface {
         return $response;
     }
 }

--- a/tests/test_app/TestApp/Policy/RequestPolicy.php
+++ b/tests/test_app/TestApp/Policy/RequestPolicy.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace TestApp\Policy;
 
+use Authorization\IdentityInterface;
 use Authorization\Policy\RequestPolicyInterface;
 use Authorization\Policy\Result;
 use Cake\Http\ServerRequest;
@@ -16,9 +17,9 @@ class RequestPolicy implements RequestPolicyInterface
      *
      * @param \Authorization\IdentityInterface|null $identity Identity
      * @param \Cake\Http\ServerRequest $request Request
-     * @return bool
+     * @return bool|\Authorization\Policy\ResultInterface
      */
-    public function canAccess($identity, ServerRequest $request)
+    public function canAccess(?IdentityInterface $identity, ServerRequest $request)
     {
         if ($request->getParam('controller') === 'Articles'
             && $request->getParam('action') === 'index'
@@ -34,11 +35,11 @@ class RequestPolicy implements RequestPolicyInterface
     /**
      * Method to check if the request can be accessed
      *
-     * @param null|\Authorization\IdentityInterface Identity
+     * @param null|\Authorization\IdentityInterface|null $idenity Identity
      * @param \Cake\Http\ServerRequest $request Request
-     * @return \Authorization\Policy\ResultInterface
+     * @return \Authorization\Policy\ResultInterface|bool
      */
-    public function canEnter($identity, ServerRequest $request)
+    public function canEnter(?IdentityInterface $identity, ServerRequest $request)
     {
         if ($request->getParam('controller') === 'Articles'
             && $request->getParam('action') === 'index'


### PR DESCRIPTION
Add typehints where possible to methods. I had to move a number of assertions into the `$next` callbacks as middleware can no longer cheat and return the request.