### PR TITLE
2.x - PSR 15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,63 +1,68 @@
 {
-  "name": "cakephp/authorization",
-  "description": "Authorization abstraction layer plugin for CakePHP",
-  "keywords": [
-    "auth",
-    "authorization",
-    "access",
-    "cakephp"
-  ],
-  "type": "cakephp-plugin",
-  "require": {
-    "cakephp/core": "^4.0",
-    "psr/http-message": "^1.0"
-  },
-  "require-dev": {
-    "cakephp/cakephp": "4.x-dev as 4.0.0",
-    "cakephp/cakephp-codesniffer": "dev-next",
-    "cakephp/bake": "4.x-dev as 2.0.0",
-    "phpunit/phpunit": "^7.0"
-  },
-  "suggest": {
-    "cakephp/orm": "To use \"OrmResolver\" (Not needed separately if using full CakePHP framework)."
-  },
-  "license": "MIT",
-  "minimum-stability": "dev",
-  "prefer-stable": true,
-  "autoload": {
-    "psr-4": {
-      "Authorization\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Authorization\\Test\\": "tests/",
-      "Cake\\Test\\": "vendor/cakephp/cakephp/tests/",
-      "OverridePlugin\\": "tests/test_app/Plugin/OverridePlugin/src/",
-      "TestApp\\": "tests/test_app/TestApp/",
-      "TestPlugin\\": "tests/test_app/Plugin/TestPlugin/src/"
-    }
-  },
-  "authors": [
-    {
-      "name": "CakePHP Community",
-      "homepage": "https://github.com/cakephp/authorization/graphs/contributors"
-    }
-  ],
-  "support": {
-    "issues": "https://github.com/cakephp/authorization/issues",
-    "forum": "https://stackoverflow.com/tags/cakephp",
-    "irc": "irc://irc.freenode.org/cakephp",
-    "source": "https://github.com/cakephp/authorization"
-  },
-  "scripts": {
-    "check": [
-      "@cs-check",
-      "@test"
+    "name": "cakephp/authorization",
+    "description": "Authorization abstraction layer plugin for CakePHP",
+    "keywords": [
+        "auth",
+        "authorization",
+        "access",
+        "cakephp"
     ],
-    "cs-check": "phpcs --colors -p ./src ./tests",
-    "cs-fix": "phpcbf --colors ./src ./tests",
-    "test": "phpunit",
-    "test-coverage": "phpunit --coverage-clover=clover.xml"
-  }
+    "type": "cakephp-plugin",
+    "require": {
+        "cakephp/cakephp": "4.x-dev as 4.0.0",
+        "psr/http-client": "^1.0",
+        "psr/http-message": "^1.0",
+        "psr/http-server-handler": "^1.0",
+        "psr/http-server-middleware": "^1.0"
+    },
+    "require-dev": {
+        "cakephp/cakephp-codesniffer": "dev-next",
+        "cakephp/bake": "4.x-dev as 2.0.0",
+        "phpunit/phpunit": "^7.0"
+    },
+    "suggest": {
+        "cakephp/orm": "To use \"OrmResolver\" (Not needed separately if using full CakePHP framework)."
+    },
+    "license": "MIT",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "Authorization\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Authorization\\Test\\": "tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/",
+            "OverridePlugin\\": "tests/test_app/Plugin/OverridePlugin/src/",
+            "TestApp\\": "tests/test_app/TestApp/",
+            "TestPlugin\\": "tests/test_app/Plugin/TestPlugin/src/"
+        }
+    },
+    "authors": [
+        {
+            "name": "CakePHP Community",
+            "homepage": "https://github.com/cakephp/authorization/graphs/contributors"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/cakephp/authorization/issues",
+        "forum": "https://stackoverflow.com/tags/cakephp",
+        "irc": "irc://irc.freenode.org/cakephp",
+        "source": "https://github.com/cakephp/authorization"
+    },
+    "scripts": {
+        "check": [
+            "@cs-check",
+            "@test"
+        ],
+        "cs-check": "phpcs --colors -p ./src ./tests",
+        "cs-fix": "phpcbf --colors ./src ./tests",
+        "test": "phpunit",
+        "test-coverage": "phpunit --coverage-clover=clover.xml"
+    },
+    "config": {
+        "sort-packages": true
+    }
 }

--- a/docs/Policies.md
+++ b/docs/Policies.md
@@ -9,7 +9,7 @@ checks to.
 You can create policies in your `src/Policy` directory. Policy classes don't
 have a common base class or interface they are expected to implement.
 Application classes are then 'resolved' to a matching policy class. See the
-[Policy Resolvers](../Policy-Resolvers.md) section for how policies can be
+[Policy Resolvers](./Policy-Resolvers.md) section for how policies can be
 resolved.
 
 Generally you'll want to put your policies in **src/Policy** and use the

--- a/src/AuthorizationServiceProviderInterface.php
+++ b/src/AuthorizationServiceProviderInterface.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
  */
 namespace Authorization;
 
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -27,11 +26,7 @@ interface AuthorizationServiceProviderInterface
      * Returns authorization service instance.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request Request
-     * @param \Psr\Http\Message\ResponseInterface $response Response
      * @return \Authorization\AuthorizationServiceInterface
      */
-    public function getAuthorizationService(
-        ServerRequestInterface $request,
-        ResponseInterface $response
-    ): AuthorizationServiceInterface;
+    public function getAuthorizationService(ServerRequestInterface $request): AuthorizationServiceInterface;
 }

--- a/src/Middleware/RequestAuthorizationMiddleware.php
+++ b/src/Middleware/RequestAuthorizationMiddleware.php
@@ -22,6 +22,8 @@ use Authorization\Policy\ResultInterface;
 use Cake\Core\InstanceConfigTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 
 /**
@@ -34,7 +36,7 @@ use RuntimeException;
  * each controller and action, against a role based access system or any other
  * kind of authorization process that controls access to certain actions.
  */
-class RequestAuthorizationMiddleware
+class RequestAuthorizationMiddleware implements MiddlewareInterface
 {
     use InstanceConfigTrait;
 
@@ -84,16 +86,12 @@ class RequestAuthorizationMiddleware
     /**
      * Callable implementation for the middleware stack.
      *
-     * @param \Psr\Http\Message\ServerRequestInterface $request Server request.
-     * @param \Psr\Http\Message\ResponseInterface $response Response.
-     * @param callable $next The next middleware to call.
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
-    public function __invoke(
-        ServerRequestInterface $request,
-        ResponseInterface $response,
-        callable $next
-    ): ResponseInterface {
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
         $service = $this->getServiceFromRequest($request);
         $identity = $request->getAttribute($this->getConfig('identityAttribute'));
 
@@ -105,6 +103,6 @@ class RequestAuthorizationMiddleware
             throw new ForbiddenException($result);
         }
 
-        return $next($request, $response);
+        return $handler->handle($request);
     }
 }

--- a/src/Middleware/UnauthorizedHandler/ExceptionHandler.php
+++ b/src/Middleware/UnauthorizedHandler/ExceptionHandler.php
@@ -30,7 +30,6 @@ class ExceptionHandler implements HandlerInterface
     public function handle(
         Exception $exception,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $options = []
     ): ResponseInterface {
         throw $exception;

--- a/src/Middleware/UnauthorizedHandler/HandlerInterface.php
+++ b/src/Middleware/UnauthorizedHandler/HandlerInterface.php
@@ -29,14 +29,12 @@ interface HandlerInterface
      *
      * @param \Authorization\Exception\Exception $exception Authorization exception thrown by the application.
      * @param \Psr\Http\Message\ServerRequestInterface $request Server request.
-     * @param \Psr\Http\Message\ResponseInterface $response Response.
      * @param array $options Options array.
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function handle(
         Exception $exception,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $options = []
     ): ResponseInterface;
 }

--- a/src/Middleware/UnauthorizedHandler/RedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/RedirectHandler.php
@@ -17,6 +17,7 @@ namespace Authorization\Middleware\UnauthorizedHandler;
 
 use Authorization\Exception\Exception;
 use Authorization\Exception\MissingIdentityException;
+use Cake\Http\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -52,7 +53,6 @@ class RedirectHandler implements HandlerInterface
     public function handle(
         Exception $exception,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $options = []
     ): ResponseInterface {
         $options += $this->defaultOptions;
@@ -63,9 +63,11 @@ class RedirectHandler implements HandlerInterface
 
         $url = $this->getUrl($request, $options);
 
+        $response = new Response();
+
         return $response
-                ->withHeader('Location', $url)
-                ->withStatus($options['statusCode']);
+            ->withHeader('Location', $url)
+            ->withStatus($options['statusCode']);
     }
 
     /**

--- a/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
@@ -17,7 +17,6 @@ namespace Authorization\Test\TestCase\Middleware\UnauthorizedHandler;
 
 use Authorization\Exception\Exception;
 use Authorization\Middleware\UnauthorizedHandler\CakeRedirectHandler;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -47,9 +46,8 @@ class CakeRedirectHandlerTest extends TestCase
 
         $exception = new Exception();
         $request = new ServerRequest();
-        $response = new Response();
 
-        $response = $handler->handle($exception, $request, $response, [
+        $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
             ],
@@ -65,9 +63,8 @@ class CakeRedirectHandlerTest extends TestCase
 
         $exception = new Exception();
         $request = new ServerRequest();
-        $response = new Response();
 
-        $response = $handler->handle($exception, $request, $response, [
+        $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
             ],
@@ -86,9 +83,8 @@ class CakeRedirectHandlerTest extends TestCase
 
         $exception = new Exception();
         $request = new ServerRequest();
-        $response = new Response();
 
-        $response = $handler->handle($exception, $request, $response, [
+        $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
             ],
@@ -110,9 +106,8 @@ class CakeRedirectHandlerTest extends TestCase
 
         $exception = new Exception();
         $request = new ServerRequest();
-        $response = new Response();
 
-        $response = $handler->handle($exception, $request, $response, [
+        $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
             ],

--- a/tests/TestCase/Middleware/UnauthorizedHandler/ExceptionHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/ExceptionHandlerTest.php
@@ -17,7 +17,6 @@ namespace Authorization\Test\TestCase\Middleware\UnauthorizedHandler;
 
 use Authorization\Exception\Exception;
 use Authorization\Middleware\UnauthorizedHandler\ExceptionHandler;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 
@@ -29,9 +28,8 @@ class ExceptionHandlerTest extends TestCase
 
         $exception = new Exception();
         $request = new ServerRequest();
-        $response = new Response();
 
         $this->expectException(Exception::class);
-        $handler->handle($exception, $request, $response);
+        $handler->handle($exception, $request);
     }
 }

--- a/tests/TestCase/Middleware/UnauthorizedHandler/RedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/RedirectHandlerTest.php
@@ -17,7 +17,6 @@ namespace Authorization\Test\TestCase\Middleware\UnauthorizedHandler;
 
 use Authorization\Exception\Exception;
 use Authorization\Middleware\UnauthorizedHandler\RedirectHandler;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 
@@ -31,9 +30,8 @@ class RedirectHandlerTest extends TestCase
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
         ]);
-        $response = new Response();
 
-        $response = $handler->handle($exception, $request, $response, [
+        $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
             ],
@@ -55,9 +53,8 @@ class RedirectHandlerTest extends TestCase
                 'QUERY_STRING' => 'key=value',
             ],
         ]);
-        $response = new Response();
 
-        $response = $handler->handle($exception, $request, $response, [
+        $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
             ],
@@ -76,9 +73,8 @@ class RedirectHandlerTest extends TestCase
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
         ]);
-        $response = new Response();
 
-        $response = $handler->handle($exception, $request, $response, [
+        $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
             ],
@@ -117,9 +113,8 @@ class RedirectHandlerTest extends TestCase
                 'QUERY_STRING' => 'key=value',
             ],
         ]);
-        $response = new Response();
 
-        $response = $handler->handle($exception, $request, $response, [
+        $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
             ],
@@ -136,9 +131,8 @@ class RedirectHandlerTest extends TestCase
 
         $exception = new Exception();
         $request = new ServerRequest();
-        $response = new Response();
 
         $this->expectException(Exception::class);
-        $handler->handle($exception, $request, $response);
+        $handler->handle($exception, $request);
     }
 }

--- a/tests/test_app/TestApp/Http/TestRequestHandler.php
+++ b/tests/test_app/TestApp/Http/TestRequestHandler.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Http;
+
+use Cake\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class TestRequestHandler implements RequestHandlerInterface
+{
+    public $callable;
+
+    public $request;
+
+    public function __construct(?callable $callable = null)
+    {
+        $this->callable = $callable ?: function ($request) {
+            return new Response();
+        };
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->request = $request;
+
+        return ($this->callable)($request);
+    }
+}

--- a/tests/test_app/TestApp/Middleware/UnauthorizedHandler/SuppressHandler.php
+++ b/tests/test_app/TestApp/Middleware/UnauthorizedHandler/SuppressHandler.php
@@ -19,6 +19,7 @@ use Authorization\Exception\Exception;
 use Authorization\Middleware\UnauthorizedHandler\HandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
 
 class SuppressHandler implements HandlerInterface
 {
@@ -28,9 +29,8 @@ class SuppressHandler implements HandlerInterface
     public function handle(
         Exception $exception,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $options = []
     ): ResponseInterface {
-        return $response;
+        return new Response();
     }
 }


### PR DESCRIPTION
This updates the middlewares to PSR 15. Since PSR 15 middleware's `process()` method doesn't receive a response instance as argument the same has been removed from the various classes used by the middlewares.

@robertpustulka mentioned in our dev channel that the middleware are only really necessary for Cake so I think going forward it might be better to just keep the middleware and related classes in this repo and use [Phauthentic/authorization](https://github.com/Phauthentic/authorization) as dependency which is framework agnostic and supports PHP 7.1+.