### PR TITLE
Always return ResultInterface instance from AuthenticationService::can().

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,3 @@ parameters:
     ignoreErrors:
         - '#Else branch is unreachable because ternary operator condition is always true#'
         - '#Result of && is always false#'
-        - '#Strict comparison using !== between null and null will always evaluate to false#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,55 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	bootstrap="./tests/bootstrap.php"
-	>
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="./tests/bootstrap.php"
+    >
 
-	<!-- Add any additional test suites you want to run here -->
-	<testsuites>
-		<testsuite name="authorization">
-			<directory>tests/TestCase/</directory>
-		</testsuite>
-		<!-- Add plugin test suites here. -->
-	</testsuites>
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="authorization">
+            <directory>tests/TestCase/</directory>
+        </testsuite>
+        <!-- Add plugin test suites here. -->
+    </testsuites>
 
-	<!-- Setup a listener for fixtures -->
-	<listeners>
-		<listener
-			class="\Cake\TestSuite\Fixture\FixtureInjector"
-			file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-			<arguments>
-				<object class="\Cake\TestSuite\Fixture\FixtureManager"/>
-			</arguments>
-		</listener>
-	</listeners>
+    <!-- Setup a listener for fixtures -->
+    <listeners>
+        <listener
+            class="\Cake\TestSuite\Fixture\FixtureInjector"
+            file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
+            <arguments>
+                <object class="\Cake\TestSuite\Fixture\FixtureManager"/>
+            </arguments>
+        </listener>
+    </listeners>
 
-	<logging>
-		<log type="coverage-html" target="./tmp/tests/report" lowUpperBound="35" highLowerBound="70"/>
-		<!--<log type="coverage-clover" target="./tmp/tests/coverage.xml"/>-->
-		<!--<log type="coverage-php" target="/tmp/coverage.serialized"/>-->
-		<!--<log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>-->
-		<!--<log type="json" target="/tmp/logfile.json"/>-->
-		<!--<log type="tap" target="/tmp/logfile.tap"/>-->
-		<!--<log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>-->
-		<!--<log type="testdox-html" target=".//tmp/tests/testdox.html"/>-->
-		<!--<log type="testdox-text" target=".//tmp/tests/testdox.txt"/>-->
-	</logging>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
 
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">src/</directory>
-		</whitelist>
-	</filter>
-
-	<php>
-		<ini name="memory_limit" value="-1"/>
-		<!-- Postgres
-		<env name="db_dsn" value="postgres://root@localhost/cake_test_db"/>
-		-->
-		<!-- Mysql
-		<env name="db_dsn" value="mysql://root@localhost/cake_test_db"/>
-		-->
-	</php>
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <!-- Postgres
+        <env name="db_dsn" value="postgres://root@localhost/cake_test_db"/>
+        -->
+        <!-- Mysql
+        <env name="db_dsn" value="mysql://root@localhost/cake_test_db"/>
+        -->
+    </php>
 </phpunit>

--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -32,9 +32,22 @@ interface AuthorizationServiceInterface
      * @param \Authorization\IdentityInterface|null $user The user to check permissions for.
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
+     * @return bool
+     */
+    public function can(?IdentityInterface $user, string $action, $resource): bool;
+
+    /**
+     * Check whether the provided user can perform an action on a resource.
+     *
+     * This method is intended to allow your application to build
+     * conditional logic around authorization checks.
+     *
+     * @param \Authorization\IdentityInterface|null $user The user to check permissions for.
+     * @param string $action The action/operation being performed.
+     * @param mixed $resource The resource being operated on.
      * @return \Authorization\Policy\ResultInterface
      */
-    public function can(?IdentityInterface $user, string $action, $resource): ResultInterface;
+    public function canResult(?IdentityInterface $user, string $action, $resource): ResultInterface;
 
     /**
      * Apply authorization scope conditions/restrictions.

--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Authorization;
 
+use Authorization\Policy\ResultInterface;
+
 /**
  * Interface for Authorization service
  */
@@ -30,9 +32,9 @@ interface AuthorizationServiceInterface
      * @param \Authorization\IdentityInterface|null $user The user to check permissions for.
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
-     * @return bool|\Authorization\Policy\ResultInterface
+     * @return \Authorization\Policy\ResultInterface
      */
-    public function can(?IdentityInterface $user, string $action, $resource);
+    public function can(?IdentityInterface $user, string $action, $resource): ResultInterface;
 
     /**
      * Apply authorization scope conditions/restrictions.

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -47,8 +47,12 @@ class ForbiddenException extends Exception
      * @param int|null $code The code of the error, is also the HTTP status code for the error.
      * @param \Throwable|null $previous the previous exception.
      */
-    public function __construct(?ResultInterface $result = null, $message = '', ?int $code = null, ?Throwable $previous = null)
-    {
+    public function __construct(
+        ?ResultInterface $result = null,
+        $message = '',
+        ?int $code = null,
+        ?Throwable $previous = null
+    ) {
         $this->result = $result;
 
         parent::__construct($message, $code, $previous);

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -70,9 +70,17 @@ class IdentityDecorator implements IdentityInterface
     /**
      * @inheritDoc
      */
-    public function can(string $action, $resource): ResultInterface
+    public function can(string $action, $resource): bool
     {
         return $this->authorization->can($this, $action, $resource);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function canResult(string $action, $resource): ResultInterface
+    {
+        return $this->authorization->canResult($this, $action, $resource);
     }
 
     /**

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Authorization;
 
 use ArrayAccess;
+use Authorization\Policy\ResultInterface;
 use BadMethodCallException;
 use InvalidArgumentException;
 
@@ -69,7 +70,7 @@ class IdentityDecorator implements IdentityInterface
     /**
      * @inheritDoc
      */
-    public function can(string $action, $resource)
+    public function can(string $action, $resource): ResultInterface
     {
         return $this->authorization->can($this, $action, $resource);
     }

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Authorization;
 
 use ArrayAccess;
+use Authorization\Policy\ResultInterface;
 
 /**
  * Interface for describing identities that can have authorization checked.
@@ -32,9 +33,9 @@ interface IdentityInterface extends ArrayAccess
      *
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
-     * @return bool|\Authorization\Policy\ResultInterface
+     * @return \Authorization\Policy\ResultInterface
      */
-    public function can(string $action, $resource);
+    public function can(string $action, $resource): ResultInterface;
 
     /**
      * Apply authorization scope conditions/restrictions.

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -33,9 +33,18 @@ interface IdentityInterface extends ArrayAccess
      *
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
+     * @return bool
+     */
+    public function can(string $action, $resource): bool;
+
+    /**
+     * Check whether the current identity can perform an action.
+     *
+     * @param string $action The action/operation being performed.
+     * @param mixed $resource The resource being operated on.
      * @return \Authorization\Policy\ResultInterface
      */
-    public function can(string $action, $resource): ResultInterface;
+    public function canResult(string $action, $resource): ResultInterface;
 
     /**
      * Apply authorization scope conditions/restrictions.

--- a/src/Middleware/RequestAuthorizationMiddleware.php
+++ b/src/Middleware/RequestAuthorizationMiddleware.php
@@ -18,8 +18,6 @@ namespace Authorization\Middleware;
 
 use Authorization\AuthorizationServiceInterface;
 use Authorization\Exception\ForbiddenException;
-use Authorization\Policy\Result;
-use Authorization\Policy\ResultInterface;
 use Cake\Core\InstanceConfigTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -96,10 +94,7 @@ class RequestAuthorizationMiddleware implements MiddlewareInterface
         $service = $this->getServiceFromRequest($request);
         $identity = $request->getAttribute($this->getConfig('identityAttribute'));
 
-        $result = $service->can($identity, $this->getConfig('method'), $request);
-        if (!$result instanceof ResultInterface) {
-            $result = new Result($result);
-        }
+        $result = $service->canResult($identity, $this->getConfig('method'), $request);
         if (!$result->getStatus()) {
             throw new ForbiddenException($result);
         }

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -42,10 +42,10 @@ class AuthorizationServiceTest extends TestCase
         $user = null;
 
         $result = $service->can($user, 'view', new Article());
-        $this->assertFalse($result);
+        $this->assertFalse($result->getStatus());
 
         $result = $service->can($user, 'view', new Article(['visibility' => 'public']));
-        $this->assertTrue($result);
+        $this->assertTrue($result->getStatus());
     }
 
     public function testCan()
@@ -61,7 +61,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', new Article());
-        $this->assertTrue($result);
+        $this->assertTrue($result->getStatus());
     }
 
     public function testCanWithResult()
@@ -109,8 +109,8 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $article = new Article();
-        $this->assertTrue($service->can($user, 'doThat', $article));
-        $this->assertFalse($service->can($user, 'cantDoThis', $article));
+        $this->assertTrue($service->can($user, 'doThat', $article)->getStatus());
+        $this->assertFalse($service->can($user, 'cantDoThis', $article)->getStatus());
     }
 
     public function testAuthorizationCheckedWithApplyScope()
@@ -201,7 +201,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', $entity);
-        $this->assertFalse($result);
+        $this->assertFalse($result->getStatus());
     }
 
     public function testBeforeTrue()
@@ -231,7 +231,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', $entity);
-        $this->assertTrue($result);
+        $this->assertTrue($result->getStatus());
     }
 
     public function testBeforeNull()
@@ -263,7 +263,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', $entity);
-        $this->assertTrue($result);
+        $this->assertTrue($result->getStatus());
     }
 
     public function testBeforeResultTrue()

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -42,10 +42,10 @@ class AuthorizationServiceTest extends TestCase
         $user = null;
 
         $result = $service->can($user, 'view', new Article());
-        $this->assertFalse($result->getStatus());
+        $this->assertFalse($result);
 
         $result = $service->can($user, 'view', new Article(['visibility' => 'public']));
-        $this->assertTrue($result->getStatus());
+        $this->assertTrue($result);
     }
 
     public function testCan()
@@ -61,7 +61,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', new Article());
-        $this->assertTrue($result->getStatus());
+        $this->assertTrue($result);
     }
 
     public function testCanWithResult()
@@ -76,7 +76,7 @@ class AuthorizationServiceTest extends TestCase
             'role' => 'admin',
         ]);
 
-        $result = $service->can($user, 'publish', new Article());
+        $result = $service->canResult($user, 'publish', new Article());
         $this->assertInstanceOf(ResultInterface::class, $result);
     }
 
@@ -109,8 +109,8 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $article = new Article();
-        $this->assertTrue($service->can($user, 'doThat', $article)->getStatus());
-        $this->assertFalse($service->can($user, 'cantDoThis', $article)->getStatus());
+        $this->assertTrue($service->can($user, 'doThat', $article));
+        $this->assertFalse($service->can($user, 'cantDoThis', $article));
     }
 
     public function testAuthorizationCheckedWithApplyScope()
@@ -201,7 +201,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', $entity);
-        $this->assertFalse($result->getStatus());
+        $this->assertFalse($result);
     }
 
     public function testBeforeTrue()
@@ -231,7 +231,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', $entity);
-        $this->assertTrue($result->getStatus());
+        $this->assertTrue($result);
     }
 
     public function testBeforeNull()
@@ -263,7 +263,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', $entity);
-        $this->assertTrue($result->getStatus());
+        $this->assertTrue($result);
     }
 
     public function testBeforeResultTrue()
@@ -293,8 +293,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', $entity);
-        $this->assertInstanceOf(ResultInterface::class, $result);
-        $this->assertTrue($result->getStatus());
+        $this->assertTrue($result);
     }
 
     public function testBeforeResultFalse()
@@ -324,8 +323,7 @@ class AuthorizationServiceTest extends TestCase
         ]);
 
         $result = $service->can($user, 'add', $entity);
-        $this->assertInstanceOf(ResultInterface::class, $result);
-        $this->assertFalse($result->getStatus());
+        $this->assertFalse($result);
     }
 
     public function testBeforeOther()

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -452,18 +452,18 @@ class AuthorizationComponentTest extends TestCase
     public function testCan()
     {
         $article = new Article(['user_id' => 1]);
-        $this->assertTrue($this->Auth->can($article)->getStatus());
-        $this->assertTrue($this->Auth->can($article, 'delete')->getStatus());
+        $this->assertTrue($this->Auth->can($article));
+        $this->assertTrue($this->Auth->can($article, 'delete'));
 
         $article = new Article(['user_id' => 2]);
-        $this->assertFalse($this->Auth->can($article)->getStatus());
-        $this->assertFalse($this->Auth->can($article, 'delete')->getStatus());
+        $this->assertFalse($this->Auth->can($article));
+        $this->assertFalse($this->Auth->can($article, 'delete'));
     }
 
     public function testCanWithResult()
     {
         $article = new Article(['user_id' => 1]);
-        $result = $this->Auth->can($article, 'publish');
+        $result = $this->Auth->canResult($article, 'publish');
         $this->assertInstanceOf(ResultInterface::class, $result);
     }
 

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -452,12 +452,12 @@ class AuthorizationComponentTest extends TestCase
     public function testCan()
     {
         $article = new Article(['user_id' => 1]);
-        $this->assertTrue($this->Auth->can($article));
-        $this->assertTrue($this->Auth->can($article, 'delete'));
+        $this->assertTrue($this->Auth->can($article)->getStatus());
+        $this->assertTrue($this->Auth->can($article, 'delete')->getStatus());
 
         $article = new Article(['user_id' => 2]);
-        $this->assertFalse($this->Auth->can($article));
-        $this->assertFalse($this->Auth->can($article, 'delete'));
+        $this->assertFalse($this->Auth->can($article)->getStatus());
+        $this->assertFalse($this->Auth->can($article, 'delete')->getStatus());
     }
 
     public function testCanWithResult()

--- a/tests/TestCase/IdentityDecoratorTest.php
+++ b/tests/TestCase/IdentityDecoratorTest.php
@@ -6,7 +6,6 @@ namespace Authorization\Test\TestCase;
 use ArrayObject;
 use Authorization\AuthorizationServiceInterface;
 use Authorization\IdentityDecorator;
-use Authorization\Policy\Result;
 use BadMethodCallException;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -59,8 +58,8 @@ class IdentityDecoratorTest extends TestCase
         $auth->expects($this->once())
             ->method('can')
             ->with($identity, 'update', $resource)
-            ->will($this->returnValue(new Result(true)));
-        $this->assertTrue($identity->can('update', $resource)->getStatus());
+            ->will($this->returnValue(true));
+        $this->assertTrue($identity->can('update', $resource));
     }
 
     public function testApplyScopeDelegation()

--- a/tests/TestCase/IdentityDecoratorTest.php
+++ b/tests/TestCase/IdentityDecoratorTest.php
@@ -6,6 +6,7 @@ namespace Authorization\Test\TestCase;
 use ArrayObject;
 use Authorization\AuthorizationServiceInterface;
 use Authorization\IdentityDecorator;
+use Authorization\Policy\Result;
 use BadMethodCallException;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -58,8 +59,8 @@ class IdentityDecoratorTest extends TestCase
         $auth->expects($this->once())
             ->method('can')
             ->with($identity, 'update', $resource)
-            ->will($this->returnValue(true));
-        $this->assertTrue($identity->can('update', $resource));
+            ->will($this->returnValue(new Result(true)));
+        $this->assertTrue($identity->can('update', $resource)->getStatus());
     }
 
     public function testApplyScopeDelegation()

--- a/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
@@ -34,7 +34,6 @@ use RuntimeException;
 use stdClass;
 use TestApp\Http\TestRequestHandler;
 use TestApp\Identity;
-use TypeError;
 
 class AuthorizationMiddlewareTest extends TestCase
 {
@@ -95,28 +94,6 @@ class AuthorizationMiddlewareTest extends TestCase
         });
 
         $middleware = new AuthorizationMiddleware($provider, ['requireAuthorizationCheck' => false]);
-        $middleware->process($request, $handler);
-    }
-
-    public function testInvokeAppInvalid()
-    {
-        $provider = $this->createMock(AuthorizationServiceProviderInterface::class);
-        $provider
-            ->expects($this->once())
-            ->method('getAuthorizationService')
-            ->with(
-                $this->isInstanceOf(ServerRequestInterface::class)
-            )
-            ->willReturn(new stdClass());
-
-        $request = new ServerRequest();
-        $handler = new TestRequestHandler();
-
-        $middleware = new AuthorizationMiddleware($provider, ['requireAuthorizationCheck' => false]);
-
-        $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('instance of stdClass returned');
-
         $middleware->process($request, $handler);
     }
 


### PR DESCRIPTION
This allows for cleaner app code as it avoids checking type of the returned value.
The convenience of returning boolean from policy classes is still retained.