### PR TITLE
Extends authentication identity interface to resolve exception on auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "dev-next",
+        "cakephp/authentication": "2.x-dev as 2.0",
         "cakephp/bake": "4.x-dev as 2.0.0",
         "phpunit/phpunit": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,8 @@
         ],
         "cs-check": "phpcs --colors -p ./src ./tests",
         "cs-fix": "phpcbf --colors ./src ./tests",
+        "stan": "phpstan analyse src/",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.11 vimeo/psalm:^3.0 && mv composer.backup composer.json", 
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
     level: 5
     ignoreErrors:
-        - '#Else branch is unreachable because ternary operator condition is always true#'
         - '#Result of && is always false#'
         - '#Strict comparison using !== between null and null will always evaluate to false#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 5
     ignoreErrors:
+        - '#Else branch is unreachable because ternary operator condition is always true#'
         - '#Result of && is always false#'
         - '#Strict comparison using !== between null and null will always evaluate to false#'

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -95,6 +95,18 @@ class IdentityDecorator implements IdentityInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        if ($this->identity && method_exists($this->identity, 'getIdentifier')) {
+            return $this->identity->getIdentifier();
+        }
+
+        return $this->identity;
+    }
+
+    /**
      * Delegate unknown methods to decorated identity.
      *
      * @param string $method The method being invoked.

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -103,7 +103,7 @@ class IdentityDecorator implements IdentityInterface
             return $this->identity->getIdentifier();
         }
 
-        return $this->identity;
+        return null;
     }
 
     /**

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Authorization;
 
 use ArrayAccess;
+use Authentication\IdentityInterface as AI;
 
 /**
  * Interface for describing identities that can have authorization checked.
@@ -25,7 +26,7 @@ use ArrayAccess;
  * and uses ArrayAccess to expose public properties of the wrapped identity
  * implementation.
  */
-interface IdentityInterface extends ArrayAccess
+interface IdentityInterface extends ArrayAccess, AI
 {
     /**
      * Check whether the current identity can perform an action.

--- a/tests/comparisons/BookmarkEntityPolicy.php
+++ b/tests/comparisons/BookmarkEntityPolicy.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace TestApp\Policy;
 
 use Authorization\IdentityInterface;

--- a/tests/comparisons/BookmarksTablePolicy.php
+++ b/tests/comparisons/BookmarksTablePolicy.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace TestApp\Policy;
 
 use Authorization\IdentityInterface;

--- a/tests/comparisons/TestPluginUserEntityPolicy.php
+++ b/tests/comparisons/TestPluginUserEntityPolicy.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace TestPlugin\Policy;
 
 use Authorization\IdentityInterface;

--- a/tests/comparisons/TestPluginUsersTablePolicy.php
+++ b/tests/comparisons/TestPluginUsersTablePolicy.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace TestPlugin\Policy;
 
 use Authorization\IdentityInterface;

--- a/tests/comparisons/ThingPolicy.php
+++ b/tests/comparisons/ThingPolicy.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace TestApp\Policy;
 
 use Authorization\IdentityInterface;


### PR DESCRIPTION
On auth in cakephp application happans next error:

Return value of Authentication\Controller\Component\AuthenticationComponent::getIdentity() must implement interface Authentication\IdentityInterface or be null, instance of Authorization\IdentityDecorator returned 

To resolve the best to extends authentication identity interface in authorization level.