### PR TITLE
Don't include host and protocol in redirect URLs

### DIFF
--- a/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php
@@ -69,6 +69,7 @@ class CakeRedirectHandler extends RedirectHandler
         $url = $options['url'];
         if ($options['queryParam'] !== null) {
             $uri = $request->getUri();
+            /** @psalm-suppress NoInterfaceProperties */
             if (property_exists($uri, 'base')) {
                 $uri = $uri->withPath($uri->base . $uri->getPath());
             }

--- a/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php
@@ -68,7 +68,16 @@ class CakeRedirectHandler extends RedirectHandler
     {
         $url = $options['url'];
         if ($options['queryParam'] !== null) {
-            $url['?'][$options['queryParam']] = (string)$request->getUri();
+            $uri = $request->getUri();
+            if (property_exists($uri, 'base')) {
+                $uri = $uri->withPath($uri->base . $uri->getPath());
+            }
+            $redirect = $uri->getPath();
+            if ($uri->getQuery()) {
+                $redirect .= '?' . $uri->getQuery();
+            }
+
+            $url['?'][$options['queryParam']] = $redirect;
         }
 
         return Router::url($url);

--- a/src/Middleware/UnauthorizedHandler/RedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/RedirectHandler.php
@@ -101,6 +101,7 @@ class RedirectHandler implements HandlerInterface
         $url = $options['url'];
         if ($options['queryParam'] !== null && $request->getMethod() === 'GET') {
             $uri = $request->getUri();
+            /** @psalm-suppress NoInterfaceProperties */
             if (property_exists($uri, 'base')) {
                 $uri = $uri->withPath($uri->base . $uri->getPath());
             }

--- a/src/Middleware/UnauthorizedHandler/RedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/RedirectHandler.php
@@ -100,7 +100,15 @@ class RedirectHandler implements HandlerInterface
     {
         $url = $options['url'];
         if ($options['queryParam'] !== null && $request->getMethod() === 'GET') {
-            $query = urlencode($options['queryParam']) . '=' . urlencode($request->getRequestTarget());
+            $uri = $request->getUri();
+            if (property_exists($uri, 'base')) {
+                $uri = $uri->withPath($uri->base . $uri->getPath());
+            }
+            $redirect = $uri->getPath();
+            if ($uri->getQuery()) {
+                $redirect .= '?' . $uri->getQuery();
+            }
+            $query = urlencode($options['queryParam']) . '=' . urlencode($redirect);
             if (strpos($url, '?') !== false) {
                 $query = '&' . $query;
             } else {

--- a/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
@@ -20,7 +20,6 @@ use Authorization\Exception\Exception;
 use Authorization\Middleware\UnauthorizedHandler\CakeRedirectHandler;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequestFactory;
-use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
@@ -18,13 +18,12 @@ namespace Authorization\Test\TestCase\Middleware\UnauthorizedHandler;
 
 use Authorization\Exception\Exception;
 use Authorization\Middleware\UnauthorizedHandler\CakeRedirectHandler;
+use Cake\Core\Configure;
+use Cake\Http\ServerRequestFactory;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 
-/**
- * Description of CakeRedirectHandlerTest
- */
 class CakeRedirectHandlerTest extends TestCase
 {
     public function setUp(): void
@@ -46,8 +45,9 @@ class CakeRedirectHandlerTest extends TestCase
         $handler = new CakeRedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest();
-
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/admin/dashboard']
+        );
         $response = $handler->handle($exception, $request, [
             'exceptions' => [
                 Exception::class,
@@ -55,7 +55,7 @@ class CakeRedirectHandlerTest extends TestCase
         ]);
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?redirect=http%3A%2F%2Flocalhost%2F', $response->getHeaderLine('Location'));
+        $this->assertEquals('/login?redirect=%2Fadmin%2Fdashboard', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectionNamed()
@@ -63,7 +63,9 @@ class CakeRedirectHandlerTest extends TestCase
         $handler = new CakeRedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest();
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/admin/dashboard']
+        );
 
         $response = $handler->handle($exception, $request, [
             'exceptions' => [
@@ -75,7 +77,7 @@ class CakeRedirectHandlerTest extends TestCase
         ]);
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?redirect=http%3A%2F%2Flocalhost%2F', $response->getHeaderLine('Location'));
+        $this->assertEquals('/login?redirect=%2Fadmin%2Fdashboard', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectionWithQuery()
@@ -83,7 +85,9 @@ class CakeRedirectHandlerTest extends TestCase
         $handler = new CakeRedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest();
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/']
+        );
 
         $response = $handler->handle($exception, $request, [
             'exceptions' => [
@@ -98,7 +102,7 @@ class CakeRedirectHandlerTest extends TestCase
         ]);
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?foo=bar&redirect=http%3A%2F%2Flocalhost%2F', $response->getHeaderLine('Location'));
+        $this->assertEquals('/login?foo=bar&redirect=%2F', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectionNoQuery()
@@ -106,7 +110,9 @@ class CakeRedirectHandlerTest extends TestCase
         $handler = new CakeRedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest();
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/']
+        );
 
         $response = $handler->handle($exception, $request, [
             'exceptions' => [
@@ -117,5 +123,31 @@ class CakeRedirectHandlerTest extends TestCase
 
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('/login', $response->getHeaderLine('Location'));
+    }
+
+    public function testHandleRedirectWithBasePath()
+    {
+        $handler = new CakeRedirectHandler();
+        $exception = new Exception();
+
+        Configure::write('App.base', '/basedir');
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/admin/dashboard']
+        );
+
+        $response = $handler->handle($exception, $request, [
+            'exceptions' => [
+                Exception::class,
+            ],
+            'url' => [
+                '_name' => 'login',
+            ],
+        ]);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(
+            '/basedir/login?redirect=%2Fbasedir%2Fadmin%2Fdashboard',
+            $response->getHeaderLine('Location')
+        );
     }
 }

--- a/tests/TestCase/Middleware/UnauthorizedHandler/RedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/RedirectHandlerTest.php
@@ -73,7 +73,7 @@ class RedirectHandlerTest extends TestCase
 
         $exception = new Exception();
         $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_METHOD' => 'GET'],
+            ['REQUEST_METHOD' => 'GET']
         );
 
         $response = $handler->handle($exception, $request, [

--- a/tests/TestCase/Middleware/UnauthorizedHandler/RedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/RedirectHandlerTest.php
@@ -18,7 +18,8 @@ namespace Authorization\Test\TestCase\Middleware\UnauthorizedHandler;
 
 use Authorization\Exception\Exception;
 use Authorization\Middleware\UnauthorizedHandler\RedirectHandler;
-use Cake\Http\ServerRequest;
+use Cake\Core\Configure;
+use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
 
 class RedirectHandlerTest extends TestCase
@@ -28,9 +29,9 @@ class RedirectHandlerTest extends TestCase
         $handler = new RedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest([
-            'environment' => ['REQUEST_METHOD' => 'GET'],
-        ]);
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_METHOD' => 'GET']
+        );
 
         $response = $handler->handle($exception, $request, [
             'exceptions' => [
@@ -47,13 +48,13 @@ class RedirectHandlerTest extends TestCase
         $handler = new RedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest([
-            'environment' => [
+        $request = ServerRequestFactory::fromGlobals(
+            [
                 'REQUEST_METHOD' => 'GET',
                 'PATH_INFO' => '/path',
                 'QUERY_STRING' => 'key=value',
-            ],
-        ]);
+            ]
+        );
 
         $response = $handler->handle($exception, $request, [
             'exceptions' => [
@@ -71,9 +72,9 @@ class RedirectHandlerTest extends TestCase
         $handler = new RedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest([
-            'environment' => ['REQUEST_METHOD' => 'GET'],
-        ]);
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_METHOD' => 'GET'],
+        );
 
         $response = $handler->handle($exception, $request, [
             'exceptions' => [
@@ -107,13 +108,13 @@ class RedirectHandlerTest extends TestCase
         $handler = new RedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest([
-            'environment' => [
+        $request = ServerRequestFactory::fromGlobals(
+            [
                 'REQUEST_METHOD' => $method,
                 'PATH_INFO' => '/path',
                 'QUERY_STRING' => 'key=value',
-            ],
-        ]);
+            ]
+        );
 
         $response = $handler->handle($exception, $request, [
             'exceptions' => [
@@ -126,12 +127,36 @@ class RedirectHandlerTest extends TestCase
         $this->assertEquals('/login?foo=bar', $response->getHeaderLine('Location'));
     }
 
+    public function testHandleRedirectWithBasePath()
+    {
+        $handler = new RedirectHandler();
+        $exception = new Exception();
+
+        Configure::write('App.base', '/basedir');
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/path', 'REQUEST_METHOD' => 'GET']
+        );
+
+        $response = $handler->handle($exception, $request, [
+            'exceptions' => [
+                Exception::class,
+            ],
+            'url' => '/basedir/login',
+        ]);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(
+            '/basedir/login?redirect=%2Fbasedir%2Fpath',
+            $response->getHeaderLine('Location')
+        );
+    }
+
     public function testHandleException()
     {
         $handler = new RedirectHandler();
 
         $exception = new Exception();
-        $request = new ServerRequest();
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
 
         $this->expectException(Exception::class);
         $handler->handle($exception, $request);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,6 +45,7 @@ define('CORE_PATH', $root . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS
 
 Configure::write('debug', true);
 Configure::write('App', [
+    'base' => '',
     'namespace' => 'TestApp',
     'encoding' => 'UTF-8',
     'paths' => [


### PR DESCRIPTION
When fixing #34 I neglected to fix the CakeRedirectHandler. This syncs the behavior between both redirect implementations so that they only include the path + query string, and handle base dirs as well.

Fixes #115