### PR TITLE
Don't fail to load console when bake is not installed

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Authorization;
 
+use Authorization\Command\PolicyCommand;
+use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 
 /**
@@ -23,4 +25,18 @@ use Cake\Core\BasePlugin;
  */
 class Plugin extends BasePlugin
 {
+    /**
+     * Add console commands if bake is also available.
+     *
+     * @param \Cake\Console\CommandCollection $commands The command collection to update
+     * @return \Cake\Console\CommandCollection
+     */
+    public function console(CommandCollection $commands): CommandCollection
+    {
+        if (class_exists('Bake\Command\SimpleBakeCommand')) {
+            $commands->add('bake policy', PolicyCommand::class);
+        }
+
+        return $commands;
+    }
 }


### PR DESCRIPTION
The bake policy command is only useful if bake is also installed. This fixes a fatal error when authorization is installed but bake is not.