### PR TITLE
function expects one parameter

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -46,7 +46,7 @@ it starts handling the request. This hook method allows your application to
 define the ``AuthorizationService`` it wants to use. Add the following method your
 **src/Application.php**::
 
-    public function getAuthorizationService(ServerRequestInterface $request, ResponseInterface $response)
+    public function getAuthorizationService(ServerRequestInterface $request)
     {
         $resolver = new OrmResolver();
 


### PR DESCRIPTION
`public function getAuthorizationService(ServerRequestInterface $request) : AuthorizationServiceInterface
{
$resolver = new OrmResolver();
return new AuthorizationService($resolver);
}`