### PR TITLE
Test enhancement about assertion equals check

### DIFF
--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -138,7 +138,7 @@ class AuthorizationComponentTest extends TestCase
             $this->Auth->authorize($article, 'publish');
         } catch (ForbiddenException $e) {
             $result = $e->getResult();
-            $this->assertEquals('public', $result->getReason());
+            $this->assertSame('public', $result->getReason());
             $this->assertFalse($result->getStatus());
 
             throw $e;

--- a/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
@@ -127,7 +127,7 @@ class AuthorizationMiddlewareTest extends TestCase
             $identity = $request->getAttribute('identity');
             $this->assertInstanceOf(IdentityInterface::class, $identity);
             $this->assertInstanceOf(\Authentication\IdentityInterface::class, $identity);
-            $this->assertEquals(1, $identity->getIdentifier());
+            $this->assertSame(1, $identity->getIdentifier());
 
             return new Response();
         });
@@ -169,7 +169,7 @@ class AuthorizationMiddlewareTest extends TestCase
             $this->assertInstanceOf(RequestInterface::class, $request);
             $this->assertSame($service, $request->getAttribute('authorization'));
             $this->assertInstanceOf(IdentityInterface::class, $request->getAttribute('user'));
-            $this->assertEquals(1, $request->getAttribute('user')['id']);
+            $this->assertSame(1, $request->getAttribute('user')['id']);
 
             return new Response();
         });

--- a/tests/TestCase/Middleware/RequestAuthorizationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/RequestAuthorizationMiddlewareTest.php
@@ -117,7 +117,7 @@ class RequestAuthorizationMiddlewareTest extends TestCase
         try {
             $middleware->process($request, $handler);
         } catch (ForbiddenException $e) {
-            $this->assertEquals('wrong action', $e->getResult()->getReason());
+            $this->assertSame('wrong action', $e->getResult()->getReason());
 
             throw $e;
         }

--- a/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
@@ -53,8 +53,8 @@ class CakeRedirectHandlerTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?redirect=%2Fadmin%2Fdashboard', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login?redirect=%2Fadmin%2Fdashboard', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectionNamed()
@@ -75,8 +75,8 @@ class CakeRedirectHandlerTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?redirect=%2Fadmin%2Fdashboard', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login?redirect=%2Fadmin%2Fdashboard', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectionWithQuery()
@@ -100,8 +100,8 @@ class CakeRedirectHandlerTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?foo=bar&redirect=%2F', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login?foo=bar&redirect=%2F', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectionNoQuery()
@@ -120,8 +120,8 @@ class CakeRedirectHandlerTest extends TestCase
             'queryParam' => null,
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectWithBasePath()
@@ -143,8 +143,8 @@ class CakeRedirectHandlerTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals(
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame(
             '/basedir/login?redirect=%2Fadmin%2Fdashboard',
             $response->getHeaderLine('Location')
         );

--- a/tests/TestCase/Middleware/UnauthorizedHandler/RedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/RedirectHandlerTest.php
@@ -39,8 +39,8 @@ class RedirectHandlerTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?redirect=%2F', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login?redirect=%2F', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectionWithQuery()
@@ -63,8 +63,8 @@ class RedirectHandlerTest extends TestCase
             'url' => '/login?foo=bar',
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?foo=bar&redirect=%2Fpath%3Fkey%3Dvalue', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login?foo=bar&redirect=%2Fpath%3Fkey%3Dvalue', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectionNoQuery()
@@ -84,8 +84,8 @@ class RedirectHandlerTest extends TestCase
             'queryParam' => null,
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/users/login', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/users/login', $response->getHeaderLine('Location'));
     }
 
     public function httpMethodProvider()
@@ -123,8 +123,8 @@ class RedirectHandlerTest extends TestCase
             'url' => '/login?foo=bar',
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('/login?foo=bar', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login?foo=bar', $response->getHeaderLine('Location'));
     }
 
     public function testHandleRedirectWithBasePath()
@@ -144,8 +144,8 @@ class RedirectHandlerTest extends TestCase
             'url' => '/basedir/login',
         ]);
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals(
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame(
             '/basedir/login?redirect=%2Fpath',
             $response->getHeaderLine('Location')
         );


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assertion equals checking strict.