### PR TITLE
Make Exception extend HttpException to allow setting http status code

### DIFF
--- a/src/Exception/AuthorizationRequiredException.php
+++ b/src/Exception/AuthorizationRequiredException.php
@@ -16,12 +16,10 @@ declare(strict_types=1);
  */
 namespace Authorization\Exception;
 
-use Authorization\Exception\Exception as BaseException;
-
 /**
  * Exception raised when authorization is required.
  */
-class AuthorizationRequiredException extends BaseException
+class AuthorizationRequiredException extends Exception
 {
     /**
      * @inheritDoc

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace Authorization\Exception;
 
-use Cake\Core\Exception\Exception as CakeException;
+use Cake\Http\Exception\HttpException;
 
-class Exception extends CakeException
+class Exception extends HttpException
 {
 }


### PR DESCRIPTION
All of the exception handling unit tests check for a 302 redirect response. I'm not sure anything checks for an uncaught exception or if that's possible.