### PR TITLE
2.x - Improve Windows compatibility in composer require command.

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -9,7 +9,7 @@ Project's ROOT directory (where the **composer.json** file is located)
 
 .. code-block:: shell
 
-    php composer.phar require cakephp/authorization:^2.0
+    php composer.phar require "cakephp/authorization:^2.0"
 
 Load the plugin by adding the following statement in your project's
 ``src/Application.php``::


### PR DESCRIPTION
On the Windows command line the caret is an escape character, thus
composer would not receive the literal character and always install
version 2.0.0.

This will not fix the problem in Powershell, which
would require using additional escape characters that are incompatible
with other environments.