### PR TITLE
Rename authorize() to check() and authorizeAction() to checkAction().

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
             "@phpstan",
             "@psalm"
         ],
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 psalm/phar:^3.5 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 psalm/phar:^4.7 && mv composer.backup composer.json",
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     },

--- a/docs/en/component.rst
+++ b/docs/en/component.rst
@@ -45,16 +45,16 @@ the component::
     public function edit($id)
     {
         $article = $this->Articles->get($id);
-        $this->Authorization->authorize($article);
+        $this->Authorization->check($article);
         // Rest of the edit method.
     }
 
-Above we see an article being authorized for the current user. Since we haven't 
+Above we see an article being authorized for the current user. Since we haven't
 specified the action to check the request's ``action`` is used. You can specify
 a policy action with the second parameter::
 
     // Use a policy method that doesn't match the current controller action.
-    $this->Authorization->authorize($article, 'update');
+    $this->Authorization->check($article, 'update');
 
 The ``authorize()`` method will raise an ``Authorization\Exception\ForbiddenException``
 when permission is denied. If you want to check authorization and get a boolean
@@ -84,7 +84,10 @@ $query = $this->Authorization->applyScope($this->Articles->find());
 If the current action has no logged in user a ``MissingIdentityException`` will
 be raised.
 
-If you want to map actions to different authorization methods use the 
+Using Action Aliases
+====================
+
+If you want to map actions to different authorization methods use the
 ``actionMap`` option::
 
    // In you controller initialize() method:
@@ -109,7 +112,7 @@ Example::
         $query = $this->Articles->find();
 
         //this will apply `list` scope while being called in `index` controller action.
-        $this->Authorization->applyScope($query); 
+        $this->Authorization->applyScope($query);
         ...
     }
 
@@ -117,15 +120,15 @@ Example::
     {
         $article = $this->Articles->get($id);
 
-        //this will authorize against `remove` entity action while being called in `delete` controller action.
-        $this->Authorization->authorize($article); 
+        // check authorization to access $article with action 'remove'
+        $this->Authorization->check($article);
         ...
     }
 
     public function add()
     {
-        //this will authorize against `insert` model action while being called in `add` controller action.
-        $this->Authorization->authorizeModel(); 
+        // check authorization to access $article with action 'insert'
+        $this->Authorization->check($article);
         ...
     }
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -68,12 +68,12 @@ authorization on a per-action basis more easily. For example, we can do::
     public function edit($id = null)
     {
         $article = $this->Article->get($id);
-        $this->Authorization->authorize($article, 'update');
+        $this->Authorization->check($article, 'update');
 
         // Rest of action
     }
 
-By calling ``authorize`` we can use our :doc:`/policies` to enforce our
+By calling ``check`` we can use our :doc:`/policies` to enforce our
 application's access control rules. You can check permissions anywhere by using
 the :doc:`identity stored in the request <checking-authorization>`.
 

--- a/src/Identity.php
+++ b/src/Identity.php
@@ -28,6 +28,7 @@ class Identity extends IdentityDecorator implements AuthenIdentityInterface
      * Identity data
      *
      * @var \Authentication\IdentityInterface
+     * @psalm-suppress NonInvariantDocblockPropertyType
      */
     protected $identity;
 

--- a/src/Policy/Result.php
+++ b/src/Policy/Result.php
@@ -43,9 +43,9 @@ class Result implements ResultInterface
      */
     public function __construct(bool $status, ?string $reason = null)
     {
-        $this->status = (bool)$status;
+        $this->status = $status;
         if ($reason !== null) {
-            $this->reason = (string)$reason;
+            $this->reason = $reason;
         }
     }
 


### PR DESCRIPTION
This deprecates `authorize()` and `authorizeAction()`.

The documentation needs some more love and there will be more discussion on the API.