### PR TITLE
Add options to applyScope()

### DIFF
--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -98,9 +98,9 @@ implementing the ``Authorization\IdentityInterface`` and using the
         /**
          * Authorization\IdentityInterface method
          */
-        public function applyScope($action, $resource)
+        public function applyScope($action, $resource, array $options = [])
         {
-            return $this->authorization->applyScope($this, $action, $resource);
+            return $this->authorization->applyScope($this, $action, $resource, $options);
         }
 
         /**
@@ -147,7 +147,7 @@ If you also use the Authentication plugin make sure to implement both interfaces
     class User extends Entity implements AuthorizationIdentity, AuthenticationIdentity
     {
         ...
-        
+
         /**
          * Authentication\IdentityInterface method
          *
@@ -157,7 +157,7 @@ If you also use the Authentication plugin make sure to implement both interfaces
         {
             return $this->id;
         }
-        
+
         ...
     }
 

--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -116,13 +116,13 @@ class AuthorizationService implements AuthorizationServiceInterface
     /**
      * @inheritDoc
      */
-    public function applyScope(?IdentityInterface $user, string $action, $resource)
+    public function applyScope(?IdentityInterface $user, string $action, $resource, array $options = [])
     {
         $this->authorizationChecked = true;
         $policy = $this->resolver->getPolicy($resource);
         $handler = $this->getScopeHandler($policy, $action);
 
-        return $handler($user, $resource);
+        return $handler($user, $resource, $options);
     }
 
     /**

--- a/src/AuthorizationServiceInterface.php
+++ b/src/AuthorizationServiceInterface.php
@@ -60,9 +60,10 @@ interface AuthorizationServiceInterface
      * @param \Authorization\IdentityInterface|null $user The user to check permissions for.
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
+     * @param array $options Application-specific scope options
      * @return mixed The modified resource.
      */
-    public function applyScope(?IdentityInterface $user, string $action, $resource);
+    public function applyScope(?IdentityInterface $user, string $action, $resource, array $options = []);
 
     /**
      * Return a boolean based on whether or not this object

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -166,9 +166,10 @@ class AuthorizationComponent extends Component
      *
      * @param mixed $resource The resource to apply a scope to.
      * @param string|null $action The action to apply a scope for.
+     * @param array $options Application-specific scope options
      * @return mixed
      */
-    public function applyScope($resource, ?string $action = null)
+    public function applyScope($resource, ?string $action = null, array $options = [])
     {
         $request = $this->getController()->getRequest();
         if ($action === null) {
@@ -179,7 +180,7 @@ class AuthorizationComponent extends Component
             throw new MissingIdentityException('Identity must exist for applyScope() call.');
         }
 
-        return $identity->applyScope($action, $resource);
+        return $identity->applyScope($action, $resource, $options);
     }
 
     /**

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -87,9 +87,9 @@ class IdentityDecorator implements IdentityInterface
     /**
      * @inheritDoc
      */
-    public function applyScope(string $action, $resource)
+    public function applyScope(string $action, $resource, array $options = [])
     {
-        return $this->authorization->applyScope($this, $action, $resource);
+        return $this->authorization->applyScope($this, $action, $resource, $options);
     }
 
     /**

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -51,9 +51,10 @@ interface IdentityInterface extends ArrayAccess
      *
      * @param string $action The action/operation being performed.
      * @param mixed $resource The resource being operated on.
+     * @param array $options Application-specific scope options
      * @return mixed The modified resource.
      */
-    public function applyScope(string $action, $resource);
+    public function applyScope(string $action, $resource, array $options = []);
 
     /**
      * Get the decorated identity

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -297,6 +297,26 @@ class AuthorizationComponentTest extends TestCase
         $this->assertSame($query, $result);
     }
 
+    public function testApplyScopeOptions()
+    {
+        $articles = new ArticlesTable();
+        $query = $this->createMock(QueryInterface::class);
+        $query->method('getRepository')
+            ->willReturn($articles);
+
+        $query->expects($this->once())
+            ->method('where')
+            ->with([
+                'custom_id' => 1,
+            ])
+            ->willReturn($query);
+
+        $result = $this->Auth->applyScope($query, 'options', ['column' => 'custom_id']);
+
+        $this->assertInstanceOf(QueryInterface::class, $result);
+        $this->assertSame($query, $result);
+    }
+
     public function testCheckSuccessWithExplicitAction()
     {
         $article = new Article(['user_id' => 1]);

--- a/tests/test_app/TestApp/Policy/ArticlesTablePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlesTablePolicy.php
@@ -36,4 +36,9 @@ class ArticlesTablePolicy
             'identity_id' => $user['id'],
         ]);
     }
+
+    public function scopeOptions(IdentityInterface $user, QueryInterface $query, array $options)
+    {
+        return $query->where([$options['column'] => $user['id']]);
+    }
 }


### PR DESCRIPTION
Refs https://github.com/cakephp/authorization/issues/170

Applications that implement `IdentityInterface` will have to add the `array $options = []` parameter.

I don't know if this along with the other api clean up should just go into a 3.0 release or if this is ok for a plugin point release.