### PR TITLE
Rename authorize() to access()

### DIFF
--- a/docs/en/component.rst
+++ b/docs/en/component.rst
@@ -45,7 +45,7 @@ the component::
     public function edit($id)
     {
         $article = $this->Articles->get($id);
-        $this->Authorization->check($article);
+        $this->Authorization->access($article);
         // Rest of the edit method.
     }
 
@@ -54,9 +54,9 @@ specified the action to check the request's ``action`` is used. You can specify
 a policy action with the second parameter::
 
     // Use a policy method that doesn't match the current controller action.
-    $this->Authorization->check($article, 'update');
+    $this->Authorization->access($article, 'update');
 
-The ``authorize()`` method will raise an ``Authorization\Exception\ForbiddenException``
+The ``access()`` method will raise an ``Authorization\Exception\ForbiddenException``
 when permission is denied. If you want to check authorization and get a boolean
 result you can use the ``can()`` method::
 
@@ -121,14 +121,14 @@ Example::
         $article = $this->Articles->get($id);
 
         // check authorization to access $article with action 'remove'
-        $this->Authorization->check($article);
+        $this->Authorization->access($article);
         ...
     }
 
     public function add()
     {
         // check authorization to access $article with action 'insert'
-        $this->Authorization->check($article);
+        $this->Authorization->access($article);
         ...
     }
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -68,7 +68,7 @@ authorization on a per-action basis more easily. For example, we can do::
     public function edit($id = null)
     {
         $article = $this->Article->get($id);
-        $this->Authorization->check($article, 'update');
+        $this->Authorization->access($article, 'update');
 
         // Rest of action
     }

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -64,8 +64,8 @@ class AuthorizationComponent extends Component
      */
     public function authorize($resource, ?string $action = null): void
     {
-        deprecationWarning('authorize() is deprecated. Use check() instead.');
-        $this->check($resource, $action);
+        deprecationWarning('authorize() is deprecated. Use access() instead.');
+        $this->access($resource, $action);
     }
 
     /**
@@ -79,7 +79,7 @@ class AuthorizationComponent extends Component
      * @return void
      * @throws \Authorization\Exception\ForbiddenException When user is not authorized.
      */
-    public function check($resource, ?string $action = null): void
+    public function access($resource, ?string $action = null): void
     {
         if ($action === null) {
             $request = $this->getController()->getRequest();
@@ -333,7 +333,7 @@ class AuthorizationComponent extends Component
 
         $authorizeModel = $this->actionConfigured($action, 'authorizeModel');
         if ($authorizeModel) {
-            $this->check($this->getController()->loadModel());
+            $this->access($this->getController()->loadModel());
         }
     }
 

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -94,7 +94,7 @@ class AuthorizationComponentTest extends TestCase
         $componentRegistry = new ComponentRegistry($controller);
         $auth = new AuthorizationComponent($componentRegistry);
 
-        $auth->check($article);
+        $auth->access($article);
     }
 
     public function testNullIdentityAllowed()
@@ -111,31 +111,31 @@ class AuthorizationComponentTest extends TestCase
         $componentRegistry = new ComponentRegistry($controller);
         $auth = new AuthorizationComponent($componentRegistry);
 
-        $this->assertNull($auth->check($article));
+        $this->assertNull($auth->access($article));
     }
 
-    public function testCheckWithUnresolvedPolicy()
+    public function testAccessWithUnresolvedPolicy()
     {
         $this->expectException(MissingPolicyException::class);
 
-        $this->Auth->check(new stdClass());
+        $this->Auth->access(new stdClass());
     }
 
-    public function testCheckFailure()
+    public function testAccessFailure()
     {
         $this->expectException(ForbiddenException::class);
 
         $article = new Article(['user_id' => 99]);
-        $this->Auth->check($article);
+        $this->Auth->access($article);
     }
 
-    public function testCheckFailureWithResult()
+    public function testAccessFailureWithResult()
     {
         $this->expectException(ForbiddenException::class);
 
         $article = new Article(['user_id' => 1, 'visibility' => 'public']);
         try {
-            $this->Auth->check($article, 'publish');
+            $this->Auth->access($article, 'publish');
         } catch (ForbiddenException $e) {
             $result = $e->getResult();
             $this->assertSame('public', $result->getReason());
@@ -145,7 +145,7 @@ class AuthorizationComponentTest extends TestCase
         }
     }
 
-    public function testCheckFailureWithStringResolver()
+    public function testAccessFailureWithStringResolver()
     {
         // Reset the system to use the string resolver
         $service = new AuthorizationService(new StringResolver());
@@ -164,16 +164,16 @@ class AuthorizationComponentTest extends TestCase
 
         $this->expectException(ForbiddenException::class);
 
-        $this->Auth->check('ArticlesTable');
+        $this->Auth->access('ArticlesTable');
     }
 
-    public function testCheckSuccessWithImplicitAction()
+    public function testAccessSuccessWithImplicitAction()
     {
         $article = new Article(['user_id' => 1]);
-        $this->assertNull($this->Auth->check($article));
+        $this->assertNull($this->Auth->access($article));
     }
 
-    public function testCheckSuccessWithMappedAction()
+    public function testAccessSuccessWithMappedAction()
     {
         $policy = $this->createMock(ArticlePolicy::class);
         $service = new AuthorizationService(new MapResolver([
@@ -194,10 +194,10 @@ class AuthorizationComponentTest extends TestCase
         $article = new Article(['user_id' => 1]);
 
         $this->Auth->setConfig('actionMap', ['edit' => 'modify']);
-        $this->assertNull($this->Auth->check($article));
+        $this->assertNull($this->Auth->access($article));
     }
 
-    public function testCheckSuccessWithStringResolver()
+    public function testAccessSuccessWithStringResolver()
     {
         // Reset the system to use the string resolver
         $service = new AuthorizationService(new StringResolver());
@@ -214,13 +214,13 @@ class AuthorizationComponentTest extends TestCase
         $this->ComponentRegistry = new ComponentRegistry($this->Controller);
         $this->Auth = new AuthorizationComponent($this->ComponentRegistry);
 
-        $this->assertNull($this->Auth->check('ArticlesTable'));
+        $this->assertNull($this->Auth->access('ArticlesTable'));
     }
 
-    public function testCheckSuccessfulWithResult()
+    public function testAccessSuccessfulWithResult()
     {
         $article = new Article(['user_id' => 1]);
-        $this->assertNull($this->Auth->check($article, 'publish'));
+        $this->assertNull($this->Auth->access($article, 'publish'));
     }
 
     /**
@@ -300,10 +300,10 @@ class AuthorizationComponentTest extends TestCase
     public function testCheckSuccessWithExplicitAction()
     {
         $article = new Article(['user_id' => 1]);
-        $this->assertNull($this->Auth->check($article, 'edit'));
+        $this->assertNull($this->Auth->access($article, 'edit'));
     }
 
-    public function testCheckWithBadIdentity()
+    public function testAccessWithBadIdentity()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/Expected that `identity` would be/');
@@ -312,7 +312,7 @@ class AuthorizationComponentTest extends TestCase
             ->withAttribute('identity', 'derp'));
 
         $article = new Article(['user_id' => 1]);
-        $this->Auth->check($article);
+        $this->Auth->access($article);
     }
 
     public function testCheckActionSuccess()


### PR DESCRIPTION
Refs https://github.com/cakephp/authorization/issues/172

This is the first PR in a series to update methods and configs to `access`.

This changes `check` to `access` because an earlier PR changed authorize to check before the RFC discussion.