### PR TITLE
Update Doc for Custom UnauthorizedHandler

### DIFF
--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -262,7 +262,7 @@ How to create a custom UnauthorizedHandler
 
     class CustomRedirectHandler implements \Authorization\Middleware\UnauthorizedHandler\HandlerInterface
 
-5) Add the flash message logic inside the ``handle()`` method like so::
+#. Add the flash message logic inside the ``handle()`` method like so::
 
     use Authorization\Exception\Exception;
     use Psr\Http\Message\ServerRequestInterface;

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -229,7 +229,7 @@ add other ``Authorization\Exception\Exception`` based exceptions to the
         ForbiddenException::class
     ],
 
-See the `RedirectHandler source <https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php>`__
+See the `RedirectHandler source <https://github.com/cakephp/authorization/blob/2.next/src/Middleware/UnauthorizedHandler/RedirectHandler.php>`__
 
 Configuration options are passed to the handler's ``handle()`` method as the
 last parameter.
@@ -291,5 +291,5 @@ This is, because we extend our handler based on the RedirectHandler present in t
     
 The ``custom_param`` appears in the ``$options`` array given to you in the ``handle()`` function inside your ``CustomRedirectHandler`` if you wish to add some more config parameters to your functionality.
 
-You can look at `CakeRedirectHandler <https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php>`__ or `RedirectHandler <https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php>`__ 
+You can look at `CakeRedirectHandler <https://github.com/cakephp/authorization/blob/2.next/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php>`__ or `RedirectHandler <https://github.com/cakephp/authorization/blob/2.next/src/Middleware/UnauthorizedHandler/RedirectHandler.php>`__ 
 how such a Handler can/should look like.

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -258,7 +258,7 @@ How to create a custom UnauthorizedHandler
 
     class CustomRedirectHandler extends \Authorization\Middleware\UnauthorizedHandler\RedirectHandler
 
-4) If not add the ``Authorization\Middleware\UnauthorizedHandler\HandlerInterface`` to your class::
+#. If not add the ``Authorization\Middleware\UnauthorizedHandler\HandlerInterface`` to your class::
 
     class CustomRedirectHandler implements \Authorization\Middleware\UnauthorizedHandler\HandlerInterface
 

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -235,7 +235,7 @@ Configuration options are passed to the handler's ``handle()`` method as the
 last parameter.
 
 Add a flash message after being redirected by an unauthorized request
-------------------------------
+----------------------------------------------------------------------
 
 Currently there is no straightforward way to add a flash message to the unauthorized redirect.
 

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -229,7 +229,7 @@ add other ``Authorization\Exception\Exception`` based exceptions to the
         ForbiddenException::class
     ],
 
-See https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php 
+See the `RedirectHandler source <https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php>`__
 
 Configuration options are passed to the handler's ``handle()`` method as the
 last parameter.

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -235,9 +235,10 @@ How to create a custom UnauthorizedHandler
 
 1) Create the folder ``src/Middleware/UnauthorizedHandler``
 2) Create a class with the namespace ``Middleware\UnauthorizedHandler`` which ends with the string ``Handler`` (like ``src/Middleware/UnauthorizedHandler/CustomRedirectHandler.php``)
-3) Add the ``Authorization\Middleware\UnauthorizedHandler\HandlerInterface`` to that class (``implements Authorization\Middleware\UnauthorizedHandler\HandlerInterface``)
+3) If you want to have the basic redirect logic then extend your class with ``extends Authorization\Middleware\UnauthorizedHandler\RedirectHandler``
+4) Add the ``Authorization\Middleware\UnauthorizedHandler\HandlerInterface`` to your class (``implements Authorization\Middleware\UnauthorizedHandler\HandlerInterface``)
 
-4) Add the flash message logic inside the ``handle()`` method like so::
+5) Add the flash message logic inside the ``handle()`` method like so::
 
     public function handle(Exception $exception, ServerRequestInterface $request, array $options = []): ResponseInterface {
         $response = parent::handle($exception, $request, $options);
@@ -245,7 +246,7 @@ How to create a custom UnauthorizedHandler
         return $response;
     }
 
-5) After you are done with the implementation of that function tell the middleware you want to use your custom handler via::
+6) After you are done with the implementation of that function tell the middleware you want to use your custom handler via::
 
     $middlewareQueue->add(new AuthorizationMiddleware($this, [
         'unauthorizedHandler' => [
@@ -256,5 +257,5 @@ How to create a custom UnauthorizedHandler
     
 The ``custom_param`` appears in the ``$options`` array given to you in the ``handle()`` function inside your ``CustomRedirectHandler``.
 
-You can look at https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php 
+You can look at https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php or https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php 
 how such a Handler can/should look like.

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -222,7 +222,7 @@ specify which exceptions you want to listen to.
 
 So in this example where we use the ``Authorization.Redirect`` handler we can
 add other ``Authorization\Exception\Exception`` based exceptions to the 
-``execeptions`` array if we wan't to handle them gracefully::
+``execeptions`` array if we want to handle them gracefully::
 
     'exceptions' => [
         MissingIdentityException::class,

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -244,13 +244,17 @@ How to create a custom UnauthorizedHandler
 
 3) If you want to have the basic redirect logic then extend your class with::
 
-    class CustomRedirectHandler extends Authorization\Middleware\UnauthorizedHandler\RedirectHandler
+    class CustomRedirectHandler extends \Authorization\Middleware\UnauthorizedHandler\RedirectHandler
 
 4) If not add the ``Authorization\Middleware\UnauthorizedHandler\HandlerInterface`` to your class::
 
-    class CustomRedirectHandler implements Authorization\Middleware\UnauthorizedHandler\HandlerInterface
+    class CustomRedirectHandler implements \Authorization\Middleware\UnauthorizedHandler\HandlerInterface
 
 5) Add the flash message logic inside the ``handle()`` method like so::
+
+    use Authorization\Exception\Exception;
+    use Psr\Http\Message\ServerRequestInterface;
+    use Psr\Http\Message\ResponseInterface;
 
     public function handle(Exception $exception, ServerRequestInterface $request, array $options = []): ResponseInterface {
         $response = parent::handle($exception, $request, $options);

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -216,7 +216,7 @@ For example::
     ]));
     
 All handlers get the thrown exception object given as a parameter.
-This excepction will always be an instance of ``Authorization\Exception\Exception``.
+This exception will always be an instance of ``Authorization\Exception\Exception``.
 In this example the ``Authorization.Redirect`` handler just gives you the option to 
 specify which exceptions you want to listen to.
 

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -215,11 +215,16 @@ For example::
         ],
     ]));
     
-Handlers catch ONLY those exceptions which extend the 
-``Authorization\Exception\Exception`` class.
+The default ``Authorization.RedirectHandler`` can only check 
+exceptions which extend the ``Authorization\Exception\Exception`` class.
 If you want to catch any other exceptions which should
-be handled via your handler they need to be added to
-the ``execeptions`` array
+be handled via your handler then they need to be added to
+the ``execeptions`` array like::
+
+    'exceptions' => [
+        MissingIdentityException::class,
+        ForbiddenException::class
+    ],
 
 Configuration options are passed to the handler's ``handle()`` method as the
 last parameter.

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -267,6 +267,8 @@ How to create a custom UnauthorizedHandler
 
 #. Tell the AuthorizationMiddleware that it should use your new custom Handler::
 
+    // in your src/Application.php
+    
     use Authorization\Exception\MissingIdentityException;
     use Authorization\Exception\ForbiddenException;
     

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -234,9 +234,21 @@ How to create a custom UnauthorizedHandler
 ------------------------------
 
 1) Create the folder ``src/Middleware/UnauthorizedHandler``
-2) Create a class with the namespace ``Middleware\UnauthorizedHandler`` which ends with the string ``Handler`` (like ``src/Middleware/UnauthorizedHandler/CustomRedirectHandler.php``)
-3) If you want to have the basic redirect logic then extend your class with ``extends Authorization\Middleware\UnauthorizedHandler\RedirectHandler``
-4) Add the ``Authorization\Middleware\UnauthorizedHandler\HandlerInterface`` to your class (``implements Authorization\Middleware\UnauthorizedHandler\HandlerInterface``)
+2) Create a class with the namespace ``Middleware\UnauthorizedHandler`` which ends with the string ``Handler`` (like ``src/Middleware/UnauthorizedHandler/CustomRedirectHandler.php``)::
+
+    <?php
+    declare(strict_types=1);
+    namespace App\Middleware\UnauthorizedHandler;
+    
+    class CustomRedirectHandler {...}
+
+3) If you want to have the basic redirect logic then extend your class with::
+
+    class CustomRedirectHandler extends Authorization\Middleware\UnauthorizedHandler\RedirectHandler
+
+4) If not add the ``Authorization\Middleware\UnauthorizedHandler\HandlerInterface`` to your class::
+
+    class CustomRedirectHandler implements Authorization\Middleware\UnauthorizedHandler\HandlerInterface
 
 5) Add the flash message logic inside the ``handle()`` method like so::
 

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -245,8 +245,8 @@ other logic you want to happen on redirect)
 How to create a custom UnauthorizedHandler
 -------------------------------------------
 
-1) Create the folder ``src/Middleware/UnauthorizedHandler``
-2) Create a class with the namespace ``Middleware\UnauthorizedHandler`` which ends with the string ``Handler`` (like ``src/Middleware/UnauthorizedHandler/CustomRedirectHandler.php``)::
+#. Create the folder ``src/Middleware/UnauthorizedHandler``
+#. Create a class with the namespace ``Middleware\UnauthorizedHandler`` which ends with the string ``Handler`` (like ``src/Middleware/UnauthorizedHandler/CustomRedirectHandler.php``)::
 
     <?php
     declare(strict_types=1);

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -215,16 +215,21 @@ For example::
         ],
     ]));
     
-The default ``Authorization.RedirectHandler`` can only check 
-exceptions which extend the ``Authorization\Exception\Exception`` class.
-If you want to catch any other exceptions which should
-be handled via your handler then they need to be added to
-the ``execeptions`` array like::
+All handlers get the thrown exception object given as a parameter.
+This excepction will always be an instance of ``Authorization\Exception\Exception``.
+In this example the ``Authorization.Redirect`` handler just gives you the option to 
+specify which exceptions you want to listen to.
+
+So in this example where we use the ``Authorization.Redirect`` handler we can
+add other ``Authorization\Exception\Exception`` based exceptions to the 
+``execeptions`` array if we wan't to handle them gracefully::
 
     'exceptions' => [
         MissingIdentityException::class,
         ForbiddenException::class
     ],
+
+See https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php 
 
 Configuration options are passed to the handler's ``handle()`` method as the
 last parameter.

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -294,5 +294,5 @@ How to create a custom UnauthorizedHandler
     
 The ``custom_param`` appears in the ``$options`` array given to you in the ``handle()`` function inside your ``CustomRedirectHandler``.
 
-You can look at https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php or https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php 
+You can look at `CakeRedirectHandler <https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php>`__ or `RedirectHandler <https://github.com/cakephp/authorization/blob/master/src/Middleware/UnauthorizedHandler/RedirectHandler.php>`__ 
 how such a Handler can/should look like.

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -201,6 +201,8 @@ Both redirect handlers share the same configuration options:
 
 For example::
 
+    use Authorization\Exception\MissingIdentityException;
+    
     $middlewareQueue->add(new AuthorizationMiddleware($this, [
         'unauthorizedHandler' => [
             'className' => 'Authorization.Redirect',
@@ -264,9 +266,18 @@ How to create a custom UnauthorizedHandler
 
 6) After you are done with the implementation of that function tell the middleware you want to use your custom handler via::
 
+    use Authorization\Exception\MissingIdentityException;
+    use Authorization\Exception\ForbiddenException;
+    
     $middlewareQueue->add(new AuthorizationMiddleware($this, [
         'unauthorizedHandler' => [
             'className' => 'CustomRedirect',
+            'url' => '/users/login',
+            'queryParam' => 'redirectUrl',
+            'exceptions' => [
+                MissingIdentityException::class,
+                ForbiddenException::class
+            ],
             'custom_param' => true,
         ],
     ]));

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -243,7 +243,7 @@ Therefore you need to create your own Handler which adds th flash message (or an
 other logic you want to happen on redirect)
 
 How to create a custom UnauthorizedHandler
-------------------------------
+-------------------------------------------
 
 1) Create the folder ``src/Middleware/UnauthorizedHandler``
 2) Create a class with the namespace ``Middleware\UnauthorizedHandler`` which ends with the string ``Handler`` (like ``src/Middleware/UnauthorizedHandler/CustomRedirectHandler.php``)::

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -254,7 +254,7 @@ How to create a custom UnauthorizedHandler
     
     class CustomRedirectHandler {...}
 
-3) If you want to have the basic redirect logic then extend your class with::
+#. If you want to have the basic redirect logic then extend your class with::
 
     class CustomRedirectHandler extends \Authorization\Middleware\UnauthorizedHandler\RedirectHandler
 


### PR DESCRIPTION
1) I changed the demo config for the already present ``Authorization.Redirect`` Handler because I think redirecting an already logged in user to the login form is not very useful just because the user tried to access something he wasn't allowed to.

2) I adjusted the doc on how to handle unauthorized requests and how to implement a custom handler for that. The slack support channel had numerous people asking how to show flash messages after being redirected by the unauthorized handler.

Sure it could also be implemented in the already present RedirectHandler in the plugin, but any logic beyond that still needs a custom handler and this doc should be more clear for all the people who are not that deeply invested in the whole OOP you need to do here 😉 