### PR TITLE
Fixes composer command for cakephp3

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -9,7 +9,7 @@ Project's ROOT directory (where the **composer.json** file is located)
 
 .. code-block:: shell
 
-    php composer.phar require cakephp/authorization
+    php composer.phar require "cakephp/authorization:^1.0"
 
 Load the plugin by adding the following statement in your project's
 ``src/Application.php``::


### PR DESCRIPTION
The command mentioned in the documentation directly tries to install 2.x plugin. For cakephp3, We require version 1.x plugin.