### PR TITLE
Update 1.x docs to deploy with github actions

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,22 @@
+---
+name: 'deploy_docs 1.x'
+
+on:
+  push:
+    branches:
+      - 1.x
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          git_remote_url: 'ssh://dokku@apps.cakephp.org:22/authorization-docs-1'
+          ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}

--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -3,13 +3,21 @@ FROM markstory/cakephp-docs-builder as builder
 
 COPY docs /data/docs
 
+ENV LANGS="en"
+
 # Build docs with sphinx
 RUN cd /data/docs-builder && \
   make website SOURCE=/data/docs DEST=/data/website
 
 # Build a small nginx container with just the static site in it.
-FROM nginx:1.15-alpine
+FROM markstory/cakephp-docs-builder:runtime as runtime
 
+# Configure search index script
+ENV LANGS="en"
+ENV SEARCH_SOURCE="/data/docs"
+ENV SEARCH_URL_PREFIX="/authorization/1"
+
+COPY --from=builder /data/docs /data/docs
 COPY --from=builder /data/website /data/website
 COPY --from=builder /data/docs-builder/nginx.conf /etc/nginx/conf.d/default.conf
 
@@ -18,3 +26,5 @@ RUN cp -R /data/website/html/* /usr/share/nginx/html \
   && rm -rf /data/website/
 
 RUN ln -s /usr/share/nginx/html /usr/share/nginx/html/1.1
+
+CMD ["/data/run.sh"]


### PR DESCRIPTION
This will let us rebuild containers for authorization 1.x docs in the future if we need to, and lets us retire another job from jenkins.