### PR TITLE
Update policies.rst

### DIFF
--- a/docs/en/policies.rst
+++ b/docs/en/policies.rst
@@ -84,7 +84,7 @@ a list view to the current user::
 
     namespace App\Policy;
 
-    class ArticlesPolicy
+    class ArticlesTablePolicy
     {
         public function scopeIndex($user, $query)
         {


### PR DESCRIPTION
The Policy class name must contain "Table" - it does not work otherwise. 

It is resolved in src/Policy/OrmResolver.php, getRepositoryPolicy() and $name contains "Table".