### PR TITLE
Correct interface name in docs

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -34,7 +34,8 @@ imports::
     use Psr\Http\Message\ResponseInterface;
     use Psr\Http\Message\ServerRequestInterface;
 
-Add the ``AuthorizationProviderInterface`` to the implemented interfaces on your application::
+Add the ``AuthorizationServiceProviderInterface`` to the implemented interfaces
+on your application::
 
     class Application extends BaseApplication implements AuthorizationServiceProviderInterface
 

--- a/docs/es/index.rst
+++ b/docs/es/index.rst
@@ -31,7 +31,8 @@ En **src/Application.php** agregue lo siguiente a las importaciones de la clase:
     use Psr\Http\Message\ResponseInterface;
     use Psr\Http\Message\ServerRequestInterface;
 
-Agregue la ``AuthorizationProviderInterface`` a las interfaces implementadas en su aplicación::
+Agregue la ``AuthorizationServiceProviderInterface`` a las interfaces
+implementadas en su aplicación::
 
     class Application extends BaseApplication implements AuthorizationServiceProviderInterface
 

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -33,8 +33,8 @@ autorisations. Commençons par mettre en place le middleware. Dans
     use Psr\Http\Message\ResponseInterface;
     use Psr\Http\Message\ServerRequestInterface;
 
-Ajoutez ``AuthorizationProviderInterface`` aux interfaces implémentées par votre
-classe Application::
+Ajoutez ``AuthorizationServiceProviderInterface`` aux interfaces implémentées par
+votre classe Application::
 
     class Application extends BaseApplication implements AuthorizationServiceProviderInterface
 


### PR DESCRIPTION
Replace `AuthorizationProviderInterface` with correct interface name `AuthorizationServiceProviderInterface` in documentation.