### PR TITLE
Fix ControllerHookPolicy Code Example

### DIFF
--- a/docs/en/policy-resolvers.rst
+++ b/docs/en/policy-resolvers.rst
@@ -111,9 +111,12 @@ our controller method::
 
     class ControllerHookPolicy
     {
-        public function __call($user, $controller)
+        public function __call(string $name, array $arguments)
         {
-            return $controller->isAuthorized($user);
+            /** @var ?\Authorization\Identity $user */
+            [$user, $controller] = $arguments;
+
+            return $controller->isAuthorized($user?->getOriginalData());
         }
     }
 
@@ -136,6 +139,7 @@ a policy resolver that will resolve controllers to our custom policy::
             if ($resource instanceof Controller) {
                 return new ControllerHookPolicy();
             }
+
             throw new MissingPolicyException([get_class($resource)]);
         }
     }


### PR DESCRIPTION
The old example had incorrect parameters for the [__call](https://www.php.net/manual/en/language.oop5.overloading.php#object.call) method. The first param is the name of the method being called. The second param is all the arguments that were passed to the called method.

We are also given an identity, not an array which is what `isAuthorized` expects. To fix this we can pass `$user->getOriginalData()` to the old `isAuthorized` methods.