### PR TITLE
3.x: fix basepath in redirecthandler

### DIFF
--- a/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/CakeRedirectHandler.php
@@ -77,6 +77,11 @@ class CakeRedirectHandler extends RedirectHandler
             $url['?'][$options['queryParam']] = $redirect;
         }
 
+        $requestBase = $request->getAttribute('base');
+        if ($requestBase) {
+            $url['_base'] = $requestBase;
+        }
+
         return Router::url($url);
     }
 }

--- a/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
+++ b/tests/TestCase/Middleware/UnauthorizedHandler/CakeRedirectHandlerTest.php
@@ -18,7 +18,6 @@ namespace Authorization\Test\TestCase\Middleware\UnauthorizedHandler;
 
 use Authorization\Exception\Exception;
 use Authorization\Middleware\UnauthorizedHandler\CakeRedirectHandler;
-use Cake\Core\Configure;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -129,10 +128,10 @@ class CakeRedirectHandlerTest extends TestCase
         $handler = new CakeRedirectHandler();
         $exception = new Exception();
 
-        Configure::write('App.base', '/basedir');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/admin/dashboard']
         );
+        $request = $request->withAttribute('base', '/basedir');
 
         $response = $handler->handle($exception, $request, [
             'exceptions' => [


### PR DESCRIPTION
The current tests for 3.x fail due to the fact that the basepath is not handled correctly.
```
1) Authorization\Test\TestCase\Middleware\UnauthorizedHandler\CakeRedirectHandlerTest::testHandleRedirectWithBasePath
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/basedir/login?redirect=%2Fadmin%2Fdashboard'
+'/login?redirect=%2Fadmin%2Fdashboard'
```