### PR TITLE
Correct PHP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "cakephp/http": "^4.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
According to https://github.com/cakephp/authorization/releases/tag/2.3.0

> Authorization 2.3.0 requires at least CakePHP 4.4.0 and PHP 7.4