### PR TITLE
Declare some missing dynamic properties in tests

### DIFF
--- a/tests/TestCase/Command/PolicyCommandTest.php
+++ b/tests/TestCase/Command/PolicyCommandTest.php
@@ -24,10 +24,14 @@ use Cake\TestSuite\StringCompareTrait;
 /**
  * PolicyCommand test class
  */
-#[\AllowDynamicProperties]
 class PolicyCommandTest extends ConsoleIntegrationTestCase
 {
     use StringCompareTrait;
+
+    /**
+     * @var string
+     */
+    protected $comparisonDir = '';
 
     /**
      * @var string

--- a/tests/TestCase/Command/PolicyCommandTest.php
+++ b/tests/TestCase/Command/PolicyCommandTest.php
@@ -24,6 +24,7 @@ use Cake\TestSuite\StringCompareTrait;
 /**
  * PolicyCommand test class
  */
+#[\AllowDynamicProperties]
 class PolicyCommandTest extends ConsoleIntegrationTestCase
 {
     use StringCompareTrait;

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -41,9 +41,18 @@ use UnexpectedValueException;
 /**
  * AuthorizationComponentTest class
  */
-#[\AllowDynamicProperties]
 class AuthorizationComponentTest extends TestCase
 {
+    /**
+     * @var \Cake\Controller\Controller
+     */
+    protected $Controller;   
+
+    /**
+     * @var \Cake\Controller\ComponentRegistry
+     */
+    protected $ComponentRegistry;   
+
     /**
      * @var \Authorization\Controller\Component\AuthorizationComponent
      */

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -41,6 +41,7 @@ use UnexpectedValueException;
 /**
  * AuthorizationComponentTest class
  */
+#[\AllowDynamicProperties]
 class AuthorizationComponentTest extends TestCase
 {
     /**

--- a/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizationComponentTest.php
@@ -46,12 +46,12 @@ class AuthorizationComponentTest extends TestCase
     /**
      * @var \Cake\Controller\Controller
      */
-    protected $Controller;   
+    protected $Controller;
 
     /**
      * @var \Cake\Controller\ComponentRegistry
      */
-    protected $ComponentRegistry;   
+    protected $ComponentRegistry;
 
     /**
      * @var \Authorization\Controller\Component\AuthorizationComponent


### PR DESCRIPTION
Adds the required trait to suppress deprecation warnings related to dynamic props in the plugin test suite.

I figured the trait was the best solution since these are just test cases, however if it would be better for me to just declare the props explicitly (& well-typed) I'm happy to do that instead.