### PR TITLE
Add support for magic calls in scope

### DIFF
--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -156,7 +156,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     {
         $method = 'scope' . ucfirst($action);
 
-        if (!method_exists($policy, $method)) {
+        if (!method_exists($policy, $method) && !method_exists($policy, '__call')) {
             throw new MissingMethodException([$method, $action, get_class($policy)]);
         }
 

--- a/tests/TestCase/AuthorizationServiceTest.php
+++ b/tests/TestCase/AuthorizationServiceTest.php
@@ -96,7 +96,7 @@ class AuthorizationServiceTest extends TestCase
         $this->assertTrue($service->authorizationChecked());
     }
 
-    public function testCallingMagicCallPolicy()
+    public function testCallingMagicCanCallPolicy()
     {
         $resolver = new MapResolver([
             Article::class => MagicCallPolicy::class,
@@ -111,6 +111,23 @@ class AuthorizationServiceTest extends TestCase
         $article = new Article();
         $this->assertTrue($service->can($user, 'doThat', $article));
         $this->assertFalse($service->can($user, 'cantDoThis', $article));
+    }
+
+    public function testCallingMagicScopeCallPolicy()
+    {
+        $resolver = new MapResolver([
+            Article::class => MagicCallPolicy::class,
+        ]);
+        $service = new AuthorizationService($resolver);
+
+        $user = new IdentityDecorator($service, [
+            'id' => 9,
+            'role' => 'admin',
+        ]);
+
+        $article = new Article();
+        $this->assertTrue($service->applyScope($user, 'this', $article));
+        $this->assertFalse($service->applyScope($user, 'somethingElse', $article));
     }
 
     public function testAuthorizationCheckedWithApplyScope()

--- a/tests/test_app/TestApp/Policy/MagicCallPolicy.php
+++ b/tests/test_app/TestApp/Policy/MagicCallPolicy.php
@@ -21,6 +21,10 @@ class MagicCallPolicy
             return true;
         }
 
+        if ($name === 'scopeThis') {
+            return true;
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
Somehow this was missing. Magic `__call` for `can*` is already supported.