### PR TITLE
Fix Applying Policy Scopes Link

### DIFF
--- a/docs/en/policies.rst
+++ b/docs/en/policies.rst
@@ -134,4 +134,4 @@ Before hooks are expected to return one of three values:
   
 Applying Policies
 -----------------
-See :ref:`applying-policy-scopes` for how to apply policies in your controller actions.
+See `Applying Policy Scopes <component.html#applying-policy-scopes>`_ for how to apply policies in your controller actions.


### PR DESCRIPTION
The link wasn't working before. I tried to get the reference working, but I couldn't figure it out so I replaced it with a link.