### PR TITLE
Set missing reference for applying-policy-scopes

### DIFF
--- a/docs/en/component.rst
+++ b/docs/en/component.rst
@@ -74,6 +74,8 @@ authorization for anonymous users. Both the ``can()`` and ``authorize()`` suppor
 anonymous users. Your policies can expect to get ``null`` for the 'user' parameter
 when the user is not logged in.
 
+.. _applying-policy-scopes:
+
 Applying Policy Scopes
 ======================
 


### PR DESCRIPTION
The reference was not converted into a link in https://book.cakephp.org/authorization/2/en/policies.html#applying-policies

![grafik](https://github.com/cakephp/authorization/assets/625761/5804f551-1b0d-470b-b6b5-8935717ea59e)


