### PR TITLE
add link to 3.0 migration guide to toc

### DIFF
--- a/docs/en/contents.rst
+++ b/docs/en/contents.rst
@@ -13,3 +13,4 @@ Contents
     /component
     /request-authorization-middleware
     /2-0-migration-guide
+    /3-0-migration-guide


### PR DESCRIPTION
Seems like we forgot to add the 3.0 link to the TOC