### PR TITLE
3.next: add DIC support to OrmResolver

### DIFF
--- a/tests/test_app/TestApp/Policy/ArticlePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlePolicy.php
@@ -6,9 +6,22 @@ namespace TestApp\Policy;
 use Authorization\Policy\Result;
 use Closure;
 use TestApp\Model\Entity\Article;
+use TestApp\Service\TestService;
 
 class ArticlePolicy
 {
+    /**
+     * A service class injected via DIC
+     *
+     * @var \TestApp\Service\TestService|null
+     */
+    protected ?TestService $service;
+
+    public function __construct(?TestService $service = null)
+    {
+        $this->service = $service;
+    }
+
     /**
      * Create articles if you're an admin or author
      *
@@ -130,5 +143,10 @@ class ArticlePolicy
     public function canWithMultipleServices($user, Article $article, Closure $service1, Closure $service2)
     {
         return $service1() && $service2();
+    }
+
+    public function canWithInjectedService($user, Article $article)
+    {
+        return $this->service->serviceLogic();
     }
 }

--- a/tests/test_app/TestApp/Service/TestService.php
+++ b/tests/test_app/TestApp/Service/TestService.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Service;
+
+class TestService
+{
+    public function serviceLogic(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
This is a proposal initiated by @jamisonbryant to make at least the OrmResolver more DI aware.

Instead of having to pass on services to `->can()` etc. one can easily inject the needed services into the policies which actually need them to do whatever logic is required to authorize the current user on the given action.

To get this working from a user perspective, all they would have to adjust in their `Application::getAuthorizationService` method is
```
$ormResolver = new OrmResolver();
```
to
```
$ormResolver = new OrmResolver('App', [], $this->getContainer());
```

After that all policies retrieved by the OrmResolver can leverage constructor injection.

If we want to go this way then we should also make the MapResolver DI aware as well.