### PR TITLE
2.next: more DIC

### DIFF
--- a/src/Middleware/AuthorizationMiddleware.php
+++ b/src/Middleware/AuthorizationMiddleware.php
@@ -27,6 +27,7 @@ use Authorization\IdentityDecorator;
 use Authorization\IdentityInterface;
 use Authorization\Middleware\UnauthorizedHandler\UnauthorizedHandlerTrait;
 use Cake\Core\ContainerApplicationInterface;
+use Cake\Core\ContainerInterface;
 use Cake\Core\InstanceConfigTrait;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
@@ -74,14 +75,25 @@ class AuthorizationMiddleware implements MiddlewareInterface
     protected $subject;
 
     /**
+     * The container instance from the application
+     *
+     * @var \Cake\Core\ContainerInterface|null
+     */
+    protected $container;
+
+    /**
      * Constructor.
      *
      * @param \Authorization\AuthorizationServiceInterface|\Authorization\AuthorizationServiceProviderInterface $subject Authorization service or provider instance.
      * @param array $config Config array.
+     * @param \Cake\Core\ContainerInterface|null $container The container instance from the application
      * @throws \InvalidArgumentException
      */
-    public function __construct($subject, array $config = [])
-    {
+    public function __construct(
+        $subject,
+        array $config = [],
+        ?ContainerInterface $container = null
+    ) {
         /** @psalm-suppress DocblockTypeContradiction */
         if (
             !$subject instanceof AuthorizationServiceInterface &&
@@ -104,6 +116,7 @@ class AuthorizationMiddleware implements MiddlewareInterface
         }
 
         $this->subject = $subject;
+        $this->container = $container;
         $this->setConfig($config);
     }
 
@@ -122,6 +135,8 @@ class AuthorizationMiddleware implements MiddlewareInterface
         if ($this->subject instanceof ContainerApplicationInterface) {
             $container = $this->subject->getContainer();
             $container->add(AuthorizationService::class, $service);
+        } elseif ($this->container) {
+            $this->container->add(AuthorizationService::class, $service);
         }
 
         $attribute = $this->getConfig('identityAttribute');

--- a/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
@@ -24,6 +24,7 @@ use Authorization\Exception\Exception;
 use Authorization\IdentityDecorator;
 use Authorization\IdentityInterface;
 use Authorization\Middleware\AuthorizationMiddleware;
+use Cake\Core\Container;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
@@ -301,5 +302,30 @@ class AuthorizationMiddlewareTest extends TestCase
 
         $container = $application->getContainer();
         $this->assertInstanceOf(AuthorizationService::class, $container->get(AuthorizationService::class));
+    }
+
+    public function testMiddlewareInjectsServiceIntoDICViaCustomContainerInstance()
+    {
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/testpath'],
+            [],
+            ['username' => 'mariano', 'password' => 'password']
+        );
+        $handler = new TestRequestHandler();
+
+        $service = $this->createMock(AuthorizationServiceInterface::class);
+        $provider = $this->createMock(AuthorizationServiceProviderInterface::class);
+        $provider
+            ->expects($this->once())
+            ->method('getAuthorizationService')
+            ->with($this->isInstanceOf(ServerRequestInterface::class))
+            ->willReturn($service);
+
+        $container = new Container();
+
+        $middleware = new AuthorizationMiddleware($provider, ['requireAuthorizationCheck' => false], $container);
+        $middleware->process($request, $handler);
+
+        $this->assertEquals($service, $container->get(AuthorizationService::class));
     }
 }


### PR DESCRIPTION
yea... you read that right.... 😁 

This is a direct response to https://github.com/cakephp/authorization/issues/265#issuecomment-1877876524 and the need to set a custom DIC in the authorization handler if the passed down subject doesn't actually implement the `ContainerApplicationInterface`

This allows users to extract the container logic from the authorization service logic if they for some reason don't want it to have it all in their Application.php