### PR TITLE
fix SelectQuery namespace for Table policies

### DIFF
--- a/src/Command/PolicyCommand.php
+++ b/src/Command/PolicyCommand.php
@@ -92,7 +92,7 @@ class PolicyCommand extends SimpleBakeCommand
         $className = $data['namespace'] . '\\' . $name;
         if ($type === 'table') {
             $className = "{$data['namespace']}\Model\\Table\\{$name}{$suffix}";
-            $imports[] = 'Cake\ORM\SelectQuery';
+            $imports[] = 'Cake\ORM\Query\SelectQuery';
         } elseif ($type === 'entity') {
             $className = "{$data['namespace']}\Model\\Entity\\{$name}";
             $imports[] = $className;

--- a/templates/bake/element/table_methods.twig
+++ b/templates/bake/element/table_methods.twig
@@ -2,7 +2,7 @@
      * Apply user access controls to a query for index actions
      *
      * @param \Authorization\IdentityInterface $user The user.
-     * @param \Cake\ORM\SelectQuery $query The query to apply authorization conditions to.
+     * @param \Cake\ORM\Query\SelectQuery $query The query to apply authorization conditions to.
      * @return bool
      */
     public function scopeIndex(IdentityInterface $user, SelectQuery $query): SelectQuery

--- a/tests/comparisons/BookmarksTablePolicy.php
+++ b/tests/comparisons/BookmarksTablePolicy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TestApp\Policy;
 
 use Authorization\IdentityInterface;
-use Cake\ORM\SelectQuery;
+use Cake\ORM\Query\SelectQuery;
 
 /**
  * Bookmarks policy
@@ -15,7 +15,7 @@ class BookmarksTablePolicy
      * Apply user access controls to a query for index actions
      *
      * @param \Authorization\IdentityInterface $user The user.
-     * @param \Cake\ORM\SelectQuery $query The query to apply authorization conditions to.
+     * @param \Cake\ORM\Query\SelectQuery $query The query to apply authorization conditions to.
      * @return bool
      */
     public function scopeIndex(IdentityInterface $user, SelectQuery $query): SelectQuery

--- a/tests/comparisons/TestPluginUsersTablePolicy.php
+++ b/tests/comparisons/TestPluginUsersTablePolicy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TestPlugin\Policy;
 
 use Authorization\IdentityInterface;
-use Cake\ORM\SelectQuery;
+use Cake\ORM\Query\SelectQuery;
 
 /**
  * Users policy
@@ -15,7 +15,7 @@ class UsersTablePolicy
      * Apply user access controls to a query for index actions
      *
      * @param \Authorization\IdentityInterface $user The user.
-     * @param \Cake\ORM\SelectQuery $query The query to apply authorization conditions to.
+     * @param \Cake\ORM\Query\SelectQuery $query The query to apply authorization conditions to.
      * @return bool
      */
     public function scopeIndex(IdentityInterface $user, SelectQuery $query): SelectQuery


### PR DESCRIPTION
As reported in https://discourse.cakephp.org/t/return-value-must-be-of-type-cake-orm-selectquery-on-tablepolicy/12396/1

`Cake\ORM\SelectQuery` does not exist, only `Cake\ORM\Query\SelectQuery`