### PR TITLE
Add test for mock model policy resolution and refactor `getRepository…

### DIFF
--- a/src/Policy/OrmResolver.php
+++ b/src/Policy/OrmResolver.php
@@ -121,11 +121,10 @@ class OrmResolver implements ResolverInterface
      */
     protected function getRepositoryPolicy(RepositoryInterface $table): mixed
     {
-        $class = get_class($table);
         $tableNamespace = '\Model\Table\\';
+        $class = get_class($table);
+        $name = $table->getAlias() . 'Table';
         $namespace = str_replace('\\', '/', substr($class, 0, (int)strpos($class, $tableNamespace)));
-        /** @psalm-suppress PossiblyFalseOperand */
-        $name = substr($class, strpos($class, $tableNamespace) + strlen($tableNamespace));
 
         return $this->findPolicy($class, $name, $namespace);
     }

--- a/tests/TestCase/Policy/OrmResolverTest.php
+++ b/tests/TestCase/Policy/OrmResolverTest.php
@@ -115,6 +115,14 @@ class OrmResolverTest extends TestCase
         $this->assertInstanceOf(ArticlesTablePolicy::class, $policy);
     }
 
+    public function testGetPolicyMockModel()
+    {
+        $articles = $this->getMockForModel('Articles');
+        $resolver = new OrmResolver('TestApp');
+        $policy = $resolver->getPolicy($articles->find());
+        $this->assertInstanceOf(ArticlesTablePolicy::class, $policy);
+    }
+
     public function testGetPolicyUnknownTable()
     {
         $this->expectException(MissingPolicyException::class);


### PR DESCRIPTION
This was not possible:

```php
        $articles = $this->getMockForModel('Articles');
        $resolver = new OrmResolver('TestApp');
        $policy = $resolver->getPolicy($articles->find());
```
because it caused:
```
Authorization\Policy\Exception\MissingPolicyException: Policy for `MockObject_ArticlesTable_23778e41` has not been defined.
/home/mirko/Libs/authorization/src/Policy/OrmResolver.php:164
/home/mirko/Libs/authorization/src/Policy/OrmResolver.php:135
/home/mirko/Libs/authorization/src/Policy/OrmResolver.php:93
/home/mirko/Libs/authorization/tests/TestCase/Policy/OrmResolverTest.php:122
```

In other words, using a mock, with `get_class($table)` it was impossible to determine the corresponding policy.  
Using `$table->getAlias(). 'Table'` not only is the thing simplifies, but the mock of a model can be used.

I noticed that this can be useful for testing the Policy Scopes, not being able to use the actual model.

Example:
```php
class NotificationsTablePolicy
{
    public function scopeIndex(User $Identity, SelectQuery $Query): SelectQuery
    {
        return $Query->find('InnerJoinWithUserId', $User->id);
    }
}
```

A mock can now be used and expect that the `find()` method is called with those arguments.