### PR TITLE
Allow Closure for requireAuthorizationCheck config option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "cakephp/authentication": "^3.0 || ^4.0",
         "cakephp/bake": "^3.2",
         "cakephp/cakephp": "^5.1",
-        "cakephp/cakephp-codesniffer": "^5.1",
+        "cakephp/cakephp-codesniffer": "^5.3",
         "phpunit/phpunit": "^10.5.58 || ^11.5.3 || ^12.4 || ^13.0"
     },
     "suggest": {

--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -176,6 +176,26 @@ option::
         'requireAuthorizationCheck' => false
     ]));
 
+You can also use a Closure to conditionally skip the authorization check based
+on the request. This is useful when you need to bypass authorization for specific
+routes (e.g., plugin admin panels that manage their own authorization)::
+
+    $middlewareQueue->add(new AuthorizationMiddleware($this, [
+        'requireAuthorizationCheck' => function ($request) {
+            // Skip authorization check for specific routes
+            $path = $request->getUri()->getPath();
+            if (str_contains($path, '/admin/queue')) {
+                return false;
+            }
+
+            return true;
+        }
+    ]));
+
+The Closure receives the ``ServerRequestInterface`` and should return a boolean.
+Return ``true`` to require authorization check (default behavior), or ``false``
+to skip the check for that request.
+
 Handling Unauthorized Requests
 ------------------------------
 

--- a/src/Middleware/AuthorizationMiddleware.php
+++ b/src/Middleware/AuthorizationMiddleware.php
@@ -30,6 +30,7 @@ use Authorization\Middleware\UnauthorizedHandler\UnauthorizedHandlerTrait;
 use Cake\Core\ContainerApplicationInterface;
 use Cake\Core\ContainerInterface;
 use Cake\Core\InstanceConfigTrait;
+use Closure;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -56,7 +57,8 @@ class AuthorizationMiddleware implements MiddlewareInterface
      * - `requireAuthorizationCheck` When true the middleware will raise an exception
      *   if no authorization checks were done. This aids in ensuring that all actions
      *   check authorization. It is intended as a development aid and not to be relied upon
-     *   in production. Defaults to `true`.
+     *   in production. Defaults to `true`. Can also be a Closure that receives the
+     *   ServerRequestInterface and returns a boolean, allowing route-based control.
      *
      * @var array<string, mixed>
      */
@@ -135,7 +137,11 @@ class AuthorizationMiddleware implements MiddlewareInterface
         try {
             $response = $handler->handle($request);
 
-            if ($this->getConfig('requireAuthorizationCheck') && !$service->authorizationChecked()) {
+            $requireCheck = $this->getConfig('requireAuthorizationCheck');
+            if ($requireCheck instanceof Closure) {
+                $requireCheck = $requireCheck($request);
+            }
+            if ($requireCheck && !$service->authorizationChecked()) {
                 throw new AuthorizationRequiredException(['url' => $request->getRequestTarget()]);
             }
         } catch (Exception $exception) {

--- a/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthorizationMiddlewareTest.php
@@ -316,4 +316,68 @@ class AuthorizationMiddlewareTest extends TestCase
 
         $this->assertEquals($service, $container->get(AuthorizationService::class));
     }
+
+    public function testRequireAuthorizationCheckCallableReturnsTrue(): void
+    {
+        $this->expectException(AuthorizationRequiredException::class);
+
+        $service = $this->createMock(AuthorizationServiceInterface::class);
+        $service->expects($this->once())
+            ->method('authorizationChecked')
+            ->willReturn(false);
+
+        $request = (new ServerRequest())->withAttribute('identity', ['id' => 1]);
+        $handler = new TestRequestHandler();
+
+        $middleware = new AuthorizationMiddleware($service, [
+            'requireAuthorizationCheck' => function (ServerRequestInterface $request): bool {
+                return true;
+            },
+            'identityDecorator' => IdentityDecorator::class,
+        ]);
+        $middleware->process($request, $handler);
+    }
+
+    public function testRequireAuthorizationCheckCallableReturnsFalse(): void
+    {
+        $service = $this->createMock(AuthorizationServiceInterface::class);
+        $service->expects($this->never())
+            ->method('authorizationChecked');
+
+        $request = (new ServerRequest())->withAttribute('identity', ['id' => 1]);
+        $handler = new TestRequestHandler();
+
+        $middleware = new AuthorizationMiddleware($service, [
+            'requireAuthorizationCheck' => function (ServerRequestInterface $request): bool {
+                return false;
+            },
+            'identityDecorator' => IdentityDecorator::class,
+        ]);
+        $result = $middleware->process($request, $handler);
+
+        $this->assertInstanceOf(ResponseInterface::class, $result);
+    }
+
+    public function testRequireAuthorizationCheckCallableWithRouteBasedLogic(): void
+    {
+        $service = $this->createMock(AuthorizationServiceInterface::class);
+        $service->expects($this->never())
+            ->method('authorizationChecked');
+
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/admin/queue']);
+        $handler = new TestRequestHandler();
+
+        $middleware = new AuthorizationMiddleware($service, [
+            'requireAuthorizationCheck' => function (ServerRequestInterface $request): bool {
+                // Skip authorization check for admin/queue routes
+                $path = $request->getUri()->getPath();
+
+                return !str_contains($path, '/admin/queue');
+            },
+            'identityDecorator' => IdentityDecorator::class,
+        ]);
+        $result = $middleware->process($request, $handler);
+
+        $this->assertInstanceOf(ResponseInterface::class, $result);
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds support for a callable in the `requireAuthorizationCheck` middleware configuration option. Currently, this option only accepts a boolean value, but applications often need to conditionally skip authorization checks based on the request path or other request attributes.

## Use Case

When integrating third-party plugins that provide their own admin panels (e.g., queue management dashboards), these plugins may manage authorization independently. The host application needs a way to skip the middleware's authorization check for these specific routes without disabling it globally.

**Before this PR**, applications had to wrap the middleware in a custom closure:

```php
$middlewareQueue->add(function ($request, $handler) use ($app) {
    $path = $request->getUri()->getPath();
    $skipAuthCheck = str_contains($path, '/admin/queue');

    $middleware = new AuthorizationMiddleware($app, [
        'requireAuthorizationCheck' => !$skipAuthCheck,
    ]);

    return $middleware->process($request, $handler);
});
```

**After this PR**, the same can be achieved cleanly:

```php
$middlewareQueue->add(new AuthorizationMiddleware($this, [
    'requireAuthorizationCheck' => function ($request) {
        $path = $request->getUri()->getPath();
        if (str_contains($path, '/admin/queue')) {
            return false;
        }
        return true;
    }
]));
```

## Changes

* Modified `AuthorizationMiddleware::process()` to check if `requireAuthorizationCheck` is callable and invoke it with the request
* Updated docblock to document the callable signature
* Added 3 test cases covering:
  - Callable returning `true` (requires authorization check)
  - Callable returning `false` (skips authorization check)
  - Route-based logic example
* Updated English documentation with example usage

## Backwards Compatibility

This change is fully backwards compatible. The existing boolean behavior is preserved - the callable is only invoked if the config value is callable.