### PR TITLE
Set minimum-stability to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,6 @@
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
All required and require-dev dependencies are tagged stable releases — there is no longer a need for `minimum-stability: dev` paired with `prefer-stable: true`.

Setting `minimum-stability` explicitly to `stable` is cleaner than relying on `dev` with `prefer-stable`, and matches the convention already used in other cakephp plugins (bake, chronos, authentication, queue, elastic-search, twig-view, localized, codesniffer all dropped or set this to stable).