### PR TITLE
Support sub-directory entities and tables in OrmResolver

### DIFF
--- a/src/Policy/OrmResolver.php
+++ b/src/Policy/OrmResolver.php
@@ -103,7 +103,7 @@ class OrmResolver implements ResolverInterface
         $class = $entity::class;
         $entityNamespace = '\Model\Entity\\';
         $namespace = str_replace('\\', '/', substr($class, 0, (int)strpos($class, $entityNamespace)));
-        $name = substr($class, strpos($class, $entityNamespace) + strlen($entityNamespace));
+        $name = str_replace('\\', '/', substr($class, strpos($class, $entityNamespace) + strlen($entityNamespace)));
 
         return $this->findPolicy($class, $name, $namespace);
     }
@@ -119,7 +119,7 @@ class OrmResolver implements ResolverInterface
         $class = $table::class;
         $tableNamespace = '\Model\Table\\';
         $namespace = str_replace('\\', '/', substr($class, 0, (int)strpos($class, $tableNamespace)));
-        $name = substr($class, strpos($class, $tableNamespace) + strlen($tableNamespace));
+        $name = str_replace('\\', '/', substr($class, strpos($class, $tableNamespace) + strlen($tableNamespace)));
 
         return $this->findPolicy($class, $name, $namespace);
     }

--- a/tests/TestCase/Policy/OrmResolverTest.php
+++ b/tests/TestCase/Policy/OrmResolverTest.php
@@ -28,8 +28,12 @@ use Cake\TestSuite\TestCase;
 use OverridePlugin\Policy\TagPolicy as OverrideTagPolicy;
 use stdClass;
 use TestApp\Model\Entity\Article;
+use TestApp\Model\Entity\SubDir\Widget;
+use TestApp\Model\Table\SubDir\WidgetsTable;
 use TestApp\Policy\ArticlePolicy;
 use TestApp\Policy\ArticlesTablePolicy;
+use TestApp\Policy\SubDir\WidgetPolicy;
+use TestApp\Policy\SubDir\WidgetsTablePolicy;
 use TestApp\Policy\TestPlugin\BookmarkPolicy;
 use TestApp\Service\TestService;
 use TestPlugin\Model\Entity\Bookmark;
@@ -66,6 +70,14 @@ class OrmResolverTest extends TestCase
         $resolver = new OrmResolver('TestApp');
         $policy = $resolver->getPolicy($article);
         $this->assertInstanceOf(ArticlePolicy::class, $policy);
+    }
+
+    public function testGetPolicyDefinedSubDirEntity(): void
+    {
+        $widget = new Widget();
+        $resolver = new OrmResolver('TestApp');
+        $policy = $resolver->getPolicy($widget);
+        $this->assertInstanceOf(WidgetPolicy::class, $policy);
     }
 
     public function testGetPolicyDefinedPluginEntityAppOveride(): void
@@ -106,6 +118,16 @@ class OrmResolverTest extends TestCase
         $resolver = new OrmResolver('TestApp');
         $policy = $resolver->getPolicy($articles);
         $this->assertInstanceOf(ArticlesTablePolicy::class, $policy);
+    }
+
+    public function testGetPolicyDefinedSubDirTable(): void
+    {
+        $widgets = $this->fetchTable('SubDir/Widgets', [
+            'className' => WidgetsTable::class,
+        ]);
+        $resolver = new OrmResolver('TestApp');
+        $policy = $resolver->getPolicy($widgets);
+        $this->assertInstanceOf(WidgetsTablePolicy::class, $policy);
     }
 
     public function testGetPolicyQueryForDefinedTable(): void

--- a/tests/test_app/TestApp/Model/Entity/SubDir/Widget.php
+++ b/tests/test_app/TestApp/Model/Entity/SubDir/Widget.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Entity\SubDir;
+
+use Cake\ORM\Entity;
+
+class Widget extends Entity
+{
+}

--- a/tests/test_app/TestApp/Model/Table/SubDir/WidgetsTable.php
+++ b/tests/test_app/TestApp/Model/Table/SubDir/WidgetsTable.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Table\SubDir;
+
+use Cake\ORM\Table;
+
+class WidgetsTable extends Table
+{
+}

--- a/tests/test_app/TestApp/Policy/SubDir/WidgetPolicy.php
+++ b/tests/test_app/TestApp/Policy/SubDir/WidgetPolicy.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Policy\SubDir;
+
+class WidgetPolicy
+{
+}

--- a/tests/test_app/TestApp/Policy/SubDir/WidgetsTablePolicy.php
+++ b/tests/test_app/TestApp/Policy/SubDir/WidgetsTablePolicy.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Policy\SubDir;
+
+class WidgetsTablePolicy
+{
+}


### PR DESCRIPTION
Closes #315.

## Background

The `OrmResolver` already converts the **namespace** segment of a resource class from backslashes to forward slashes before handing it to `App::className()`:

```php
$namespace = str_replace('\\', '/', substr($class, 0, (int)strpos($class, $entityNamespace)));
```

…but the **name** segment is left as-is. For a class like `TestApp\Model\Entity\SubDir\Widget` the resolver therefore passes `App.SubDir\Widget` to `App::className()`. `App::className()` short-circuits on any embedded backslash and returns `null`, so a `MissingPolicyException` is thrown even when `App\Policy\SubDir\WidgetPolicy` exists at the expected location.

The namespace side of this conversion was added intentionally — so partial sub-directory support is already present. This change finishes the job for the name half.

## Change

Apply the same `str_replace('\\', '/', …)` to the name segment in both `getEntityPolicy()` and `getRepositoryPolicy()`.

## Note on previous discussion

Issue #315 was closed as "use FQCN" — that workaround still works (via `MapResolver` registration), and consumers who want manual control can keep doing it. This PR is additive: nothing changes for flat layouts, and the same convention `App\Policy\SubDir\WidgetPolicy` for `App\Model\Entity\SubDir\Widget` simply starts working. If maintainers prefer to keep the convention-based resolver flat-only, feel free to close.

## Verification

- `composer test` — 142 tests, 291 assertions (was 140 / 289). 2 new tests, one entity and one table, both with a `SubDir/Widget(s)` fixture.
- `composer stan` — clean.
- `composer cs-check` — clean.
