### PR TITLE
Allow class FQCN strings as authorization resources (draft, refs #135)

### DIFF
--- a/src/Policy/MapResolver.php
+++ b/src/Policy/MapResolver.php
@@ -104,7 +104,7 @@ class MapResolver implements ResolverInterface
             $class = $resource;
         } else {
             $message = sprintf(
-                'Resource must be an object or class FQCN string, `%s` given.',
+                'Resource must be an object or fully-qualified class name, `%s` given.',
                 is_string($resource) ? $resource : gettype($resource),
             );
             throw new InvalidArgumentException($message);

--- a/src/Policy/MapResolver.php
+++ b/src/Policy/MapResolver.php
@@ -89,20 +89,29 @@ class MapResolver implements ResolverInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException When a resource is not an object.
+     * Accepts either an object instance or a class FQCN string registered in
+     * the map. Strings that are not valid class names continue to raise
+     * InvalidArgumentException.
+     *
+     * @throws \InvalidArgumentException When a resource is neither an object nor a class FQCN string.
      * @throws \Authorization\Policy\Exception\MissingPolicyException When a policy for a resource has not been defined.
      */
     public function getPolicy($resource): mixed
     {
-        if (!is_object($resource)) {
-            $message = sprintf('Resource must be an object, `%s` given.', gettype($resource));
+        if (is_object($resource)) {
+            $class = $resource::class;
+        } elseif (is_string($resource) && class_exists($resource)) {
+            $class = $resource;
+        } else {
+            $message = sprintf(
+                'Resource must be an object or class FQCN string, `%s` given.',
+                is_string($resource) ? $resource : gettype($resource),
+            );
             throw new InvalidArgumentException($message);
         }
 
-        $class = $resource::class;
-
         if (!isset($this->map[$class])) {
-            throw new MissingPolicyException($resource);
+            throw new MissingPolicyException(is_object($resource) ? $resource : [$class]);
         }
 
         $policy = $this->map[$class];

--- a/src/Policy/MapResolver.php
+++ b/src/Policy/MapResolver.php
@@ -89,11 +89,11 @@ class MapResolver implements ResolverInterface
     /**
      * {@inheritDoc}
      *
-     * Accepts either an object instance or a class FQCN string registered in
+     * Accepts either an object instance or a fully-qualified class name registered in
      * the map. Strings that are not valid class names continue to raise
      * InvalidArgumentException.
      *
-     * @throws \InvalidArgumentException When a resource is neither an object nor a class FQCN string.
+     * @throws \InvalidArgumentException When a resource is neither an object nor a fully-qualified class name.
      * @throws \Authorization\Policy\Exception\MissingPolicyException When a policy for a resource has not been defined.
      */
     public function getPolicy($resource): mixed

--- a/src/Policy/OrmResolver.php
+++ b/src/Policy/OrmResolver.php
@@ -79,10 +79,10 @@ class OrmResolver implements ResolverInterface
     public function getPolicy(mixed $resource): mixed
     {
         if ($resource instanceof EntityInterface) {
-            return $this->getEntityPolicy($resource);
+            return $this->getEntityPolicy($resource::class);
         }
         if ($resource instanceof RepositoryInterface) {
-            return $this->getRepositoryPolicy($resource);
+            return $this->getRepositoryPolicy($resource::class);
         }
         if ($resource instanceof QueryInterface) {
             $repo = $resource->getRepository();
@@ -90,69 +90,48 @@ class OrmResolver implements ResolverInterface
                 throw new RuntimeException('No repository set for the query.');
             }
 
-            return $this->getRepositoryPolicy($repo);
+            return $this->getRepositoryPolicy($repo::class);
         }
         if (is_string($resource) && class_exists($resource)) {
-            return $this->getPolicyByClassName($resource);
+            if (is_subclass_of($resource, EntityInterface::class)) {
+                return $this->getEntityPolicy($resource);
+            }
+            if (is_subclass_of($resource, RepositoryInterface::class)) {
+                return $this->getRepositoryPolicy($resource);
+            }
+
+            throw new MissingPolicyException([$resource]);
         }
 
         throw new MissingPolicyException([get_debug_type($resource)]);
     }
 
     /**
-     * Locate a policy from a class name string by matching the standard
-     * entity/table namespace markers.
+     * Get a policy for an entity class.
      *
-     * @param string $class The fully qualified class name.
-     * @return mixed
-     * @throws \Authorization\Policy\Exception\MissingPolicyException When the
-     *   string does not match an entity/table namespace pattern or no policy
-     *   exists at the conventional location.
-     */
-    protected function getPolicyByClassName(string $class): mixed
-    {
-        foreach (['\Model\Entity\\', '\Model\Table\\'] as $marker) {
-            $pos = strpos($class, $marker);
-            if ($pos === false) {
-                continue;
-            }
-            $namespace = str_replace('\\', '/', substr($class, 0, $pos));
-            $name = str_replace('\\', '/', substr($class, $pos + strlen($marker)));
-
-            return $this->findPolicy($class, $name, $namespace);
-        }
-
-        throw new MissingPolicyException([$class]);
-    }
-
-    /**
-     * Get a policy for an entity
-     *
-     * @param \Cake\Datasource\EntityInterface $entity The entity to get a policy for
+     * @param string $class The entity class name to get a policy for.
      * @return mixed
      */
-    protected function getEntityPolicy(EntityInterface $entity): mixed
+    protected function getEntityPolicy(string $class): mixed
     {
-        $class = $entity::class;
         $entityNamespace = '\Model\Entity\\';
         $namespace = str_replace('\\', '/', substr($class, 0, (int)strpos($class, $entityNamespace)));
-        $name = str_replace('\\', '/', substr($class, strpos($class, $entityNamespace) + strlen($entityNamespace)));
+        $name = str_replace('\\', '/', substr($class, (int)strpos($class, $entityNamespace) + strlen($entityNamespace)));
 
         return $this->findPolicy($class, $name, $namespace);
     }
 
     /**
-     * Get a policy for a table
+     * Get a policy for a table/repository class.
      *
-     * @param \Cake\Datasource\RepositoryInterface $table The table/repository to get a policy for.
+     * @param string $class The table/repository class name to get a policy for.
      * @return mixed
      */
-    protected function getRepositoryPolicy(RepositoryInterface $table): mixed
+    protected function getRepositoryPolicy(string $class): mixed
     {
-        $class = $table::class;
         $tableNamespace = '\Model\Table\\';
         $namespace = str_replace('\\', '/', substr($class, 0, (int)strpos($class, $tableNamespace)));
-        $name = str_replace('\\', '/', substr($class, strpos($class, $tableNamespace) + strlen($tableNamespace)));
+        $name = str_replace('\\', '/', substr($class, (int)strpos($class, $tableNamespace) + strlen($tableNamespace)));
 
         return $this->findPolicy($class, $name, $namespace);
     }

--- a/src/Policy/OrmResolver.php
+++ b/src/Policy/OrmResolver.php
@@ -65,7 +65,11 @@ class OrmResolver implements ResolverInterface
     }
 
     /**
-     * Get a policy for an ORM Table, Entity or Query.
+     * Get a policy for an ORM Table, Entity, Query or class name string.
+     *
+     * Accepting an entity/table FQCN string as the resource allows checks
+     * like `$user->can('add', Article::class)` where no instance is on hand
+     * (e.g. menu rendering before a `newEmptyEntity()`).
      *
      * @param mixed $resource The resource.
      * @return mixed
@@ -88,8 +92,37 @@ class OrmResolver implements ResolverInterface
 
             return $this->getRepositoryPolicy($repo);
         }
+        if (is_string($resource) && class_exists($resource)) {
+            return $this->getPolicyByClassName($resource);
+        }
 
         throw new MissingPolicyException([get_debug_type($resource)]);
+    }
+
+    /**
+     * Locate a policy from a class name string by matching the standard
+     * entity/table namespace markers.
+     *
+     * @param string $class The fully qualified class name.
+     * @return mixed
+     * @throws \Authorization\Policy\Exception\MissingPolicyException When the
+     *   string does not match an entity/table namespace pattern or no policy
+     *   exists at the conventional location.
+     */
+    protected function getPolicyByClassName(string $class): mixed
+    {
+        foreach (['\Model\Entity\\', '\Model\Table\\'] as $marker) {
+            $pos = strpos($class, $marker);
+            if ($pos === false) {
+                continue;
+            }
+            $namespace = str_replace('\\', '/', substr($class, 0, $pos));
+            $name = str_replace('\\', '/', substr($class, $pos + strlen($marker)));
+
+            return $this->findPolicy($class, $name, $namespace);
+        }
+
+        throw new MissingPolicyException([$class]);
     }
 
     /**

--- a/src/Policy/OrmResolver.php
+++ b/src/Policy/OrmResolver.php
@@ -67,7 +67,7 @@ class OrmResolver implements ResolverInterface
     /**
      * Get a policy for an ORM Table, Entity, Query or class name string.
      *
-     * Accepting an entity/table FQCN string as the resource allows checks
+     * Accepting an entity/table fully-qualified class name as the resource allows checks
      * like `$user->can('add', Article::class)` where no instance is on hand
      * (e.g. menu rendering before a `newEmptyEntity()`).
      *

--- a/tests/TestCase/Policy/MapResolverTest.php
+++ b/tests/TestCase/Policy/MapResolverTest.php
@@ -92,7 +92,7 @@ class MapResolverTest extends TestCase
         $resolver = new MapResolver();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Resource must be an object or class FQCN string, `Foo` given.');
+        $this->expectExceptionMessage('Resource must be an object or fully-qualified class name, `Foo` given.');
 
         $resolver->getPolicy('Foo');
     }

--- a/tests/TestCase/Policy/MapResolverTest.php
+++ b/tests/TestCase/Policy/MapResolverTest.php
@@ -92,9 +92,28 @@ class MapResolverTest extends TestCase
         $resolver = new MapResolver();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Resource must be an object, `string` given.');
+        $this->expectExceptionMessage('Resource must be an object or class FQCN string, `Foo` given.');
 
         $resolver->getPolicy('Foo');
+    }
+
+    public function testGetPolicyClassNameAsResource(): void
+    {
+        $resolver = new MapResolver();
+        $resolver->map(Article::class, ArticlePolicy::class);
+
+        $result = $resolver->getPolicy(Article::class);
+        $this->assertInstanceOf(ArticlePolicy::class, $result);
+    }
+
+    public function testGetPolicyUnregisteredClassString(): void
+    {
+        $resolver = new MapResolver();
+
+        $this->expectException(MissingPolicyException::class);
+        $this->expectExceptionMessage('Policy for `TestApp\Model\Entity\Article` has not been defined.');
+
+        $resolver->getPolicy(Article::class);
     }
 
     public function testGetPolicyMissing(): void

--- a/tests/TestCase/Policy/OrmResolverTest.php
+++ b/tests/TestCase/Policy/OrmResolverTest.php
@@ -28,6 +28,7 @@ use Cake\TestSuite\TestCase;
 use OverridePlugin\Policy\TagPolicy as OverrideTagPolicy;
 use stdClass;
 use TestApp\Model\Entity\Article;
+use TestApp\Model\Entity\FakeEntity;
 use TestApp\Model\Entity\SubDir\Widget;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\SubDir\WidgetsTable;
@@ -168,6 +169,17 @@ class OrmResolverTest extends TestCase
 
         $this->expectException(MissingPolicyException::class);
         $resolver->getPolicy(TestService::class);
+    }
+
+    public function testGetPolicyFromEntityNamespacedNonEntityClassString(): void
+    {
+        // FakeEntity lives under `\Model\Entity\` and has a matching FakeEntityPolicy,
+        // but is not an EntityInterface - interface discrimination must reject it
+        // rather than wrongly resolving the policy via namespace matching.
+        $resolver = new OrmResolver('TestApp');
+
+        $this->expectException(MissingPolicyException::class);
+        $resolver->getPolicy(FakeEntity::class);
     }
 
     public function testGetPolicyFromNonClassString(): void

--- a/tests/TestCase/Policy/OrmResolverTest.php
+++ b/tests/TestCase/Policy/OrmResolverTest.php
@@ -28,6 +28,7 @@ use Cake\TestSuite\TestCase;
 use OverridePlugin\Policy\TagPolicy as OverrideTagPolicy;
 use stdClass;
 use TestApp\Model\Entity\Article;
+use TestApp\Model\Table\ArticlesTable;
 use TestApp\Policy\ArticlePolicy;
 use TestApp\Policy\ArticlesTablePolicy;
 use TestApp\Policy\TestPlugin\BookmarkPolicy;
@@ -123,6 +124,36 @@ class OrmResolverTest extends TestCase
         $articles = $this->createStub(RepositoryInterface::class);
         $resolver = new OrmResolver('TestApp');
         $resolver->getPolicy($articles);
+    }
+
+    public function testGetPolicyFromEntityClassString(): void
+    {
+        $resolver = new OrmResolver('TestApp');
+        $policy = $resolver->getPolicy(Article::class);
+        $this->assertInstanceOf(ArticlePolicy::class, $policy);
+    }
+
+    public function testGetPolicyFromTableClassString(): void
+    {
+        $resolver = new OrmResolver('TestApp');
+        $policy = $resolver->getPolicy(ArticlesTable::class);
+        $this->assertInstanceOf(ArticlesTablePolicy::class, $policy);
+    }
+
+    public function testGetPolicyFromUnrelatedClassString(): void
+    {
+        $resolver = new OrmResolver('TestApp');
+
+        $this->expectException(MissingPolicyException::class);
+        $resolver->getPolicy(TestService::class);
+    }
+
+    public function testGetPolicyFromNonClassString(): void
+    {
+        $resolver = new OrmResolver('TestApp');
+
+        $this->expectException(MissingPolicyException::class);
+        $resolver->getPolicy('NotAClassName');
     }
 
     public function testGetPolicyViaDIC(): void

--- a/tests/test_app/TestApp/Model/Entity/FakeEntity.php
+++ b/tests/test_app/TestApp/Model/Entity/FakeEntity.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Entity;
+
+/**
+ * Lives under the `\Model\Entity\` namespace but is NOT an EntityInterface.
+ *
+ * Used to prove the resolver discriminates by interface, not by namespace
+ * substring: a matching FakeEntityPolicy exists, so a substring-based lookup
+ * would wrongly resolve it, while the interface check rejects it.
+ */
+class FakeEntity
+{
+}

--- a/tests/test_app/TestApp/Policy/FakeEntityPolicy.php
+++ b/tests/test_app/TestApp/Policy/FakeEntityPolicy.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Policy;
+
+/**
+ * A policy that conventionally matches TestApp\Model\Entity\FakeEntity.
+ *
+ * Its existence is the trap: substring-based resolution would return it for a
+ * non-entity class. The interface-based resolver must NOT reach this.
+ */
+class FakeEntityPolicy
+{
+}


### PR DESCRIPTION
Closes #135 if accepted.

## Why

The recurring use case from #135 is:

```php
if ($this->Authorization->can('add', \App\Model\Entity\Article::class)) {
    echo $this->Html->link('Add new', ['action' => 'add']);
}
```

i.e. checking permission to *create* a resource at a moment when no instance exists yet (menu rendering, button visibility, list-view "New" links, before `newEmptyEntity()`).

Today this requires creating a throwaway entity just to satisfy the resolver, or mapping `ServerRequest::class` to a `RequestPolicy` and using `RequestAuthorizationMiddleware`. Both feel like workarounds.

The 2020 thread on #135 (markstory: "the only limitation … has been a lack of imagination and use cases"; LordSimal in 2023: "this will be possible in the next major version") concluded the feature is wanted but had no champion. Picking it back up.

## What

### `OrmResolver`

`getPolicy()` learns to accept a class FQCN string. If the string contains one of the conventional namespace markers (`\Model\Entity\` or `\Model\Table\`), the namespace and name segments are extracted and routed through the existing `findPolicy()` lookup — so the resolution is *identical* to what would happen for an instance of that class:

```php
$user->can('add', \App\Model\Entity\Article::class);     // App\Policy\ArticlePolicy
$user->can('access', \App\Model\Table\ArticlesTable::class); // App\Policy\ArticlesTablePolicy
```

A string that is not a class (`class_exists() === false`) is left to fall through to the existing `MissingPolicyException` path. A class that does not match either marker also throws `MissingPolicyException` — same behavior as a non-resolvable instance.

### `MapResolver`

`getPolicy()` learns to accept a class FQCN string. If the string resolves to an existing class, it is used directly as the map key:

```php
$resolver->map(Article::class, ArticlePolicy::class);
$user->can('add', Article::class);  // returns ArticlePolicy
```

A registered FQCN with no policy mapping raises `MissingPolicyException` (parity with the object case). A non-class string still raises `InvalidArgumentException`, just with an updated message that names the offending string instead of just its type.

The pre-existing `testGetPolicyPrimitive` assertion message was updated accordingly — that is the only BC-visible change in the test suite.

## Discussion points for all maintainers

1. **Should `OrmResolver` accept `class_exists($resource) === false`?** Current draft requires the class to exist. An alternative is to accept any string that contains the marker and let `findPolicy()` either return a policy or throw. Stricter is friendlier IMO but I can flip it.
2. **`MapResolver` — should we widen the type hint on `getPolicy()`?** The interface signature is `mixed`, so technically nothing changes; the docblock and message strings now describe the broader contract.
3. **Should we also allow registering policies by FQCN that *doesn't* yet exist?** Right now `MapResolver::map()` enforces `class_exists($resourceClass)` so this is moot, but if anyone uses it with classes only autoloaded under certain conditions it could be a footgun.
4. **`ResolverCollection` already chains resolvers**, so a user with a partial map + ORM resolver gets the natural fallback for free. No changes there.
5. **Anything you want me to split** (only OrmResolver, only MapResolver, etc.) — happy to.

